### PR TITLE
Fixes compatibility with Java 7

### DIFF
--- a/src/main/java/com/rollbar/Rollbar.java
+++ b/src/main/java/com/rollbar/Rollbar.java
@@ -7,7 +7,7 @@ import com.rollbar.payload.data.body.Body;
 import com.rollbar.payload.utilities.ArgumentNullException;
 import com.rollbar.payload.utilities.Validate;
 
-import java.time.Instant;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -529,7 +529,7 @@ public class Rollbar {
             custom = finalCustom;
         }
 
-        Data data = new Data(getEnvironment(), body, level, Instant.now(), getCodeVersion(), getPlatform(),
+        Data data = new Data(getEnvironment(), body, level, new Date(), getCodeVersion(), getPlatform(),
                              getLanguage(), getFramework(), getContext(), getRequest(), getPerson(), getServer(),
                              custom, null, null, null, getNotifier());
         Payload p = new Payload(getAccessToken(), data);

--- a/src/main/java/com/rollbar/payload/Payload.java
+++ b/src/main/java/com/rollbar/payload/Payload.java
@@ -10,7 +10,7 @@ import com.rollbar.payload.utilities.RollbarSerializer;
 import com.rollbar.payload.utilities.Validate;
 import com.rollbar.payload.utilities.JsonSerializable;
 
-import java.time.Instant;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public final class Payload implements JsonSerializable {
         Body body = Body.fromError(error);
         Level level = error instanceof Error ? Level.CRITICAL : Level.ERROR;
         String platform = System.getProperty("java.version");
-        Data d = new Data(environment, body, level, Instant.now(), null, platform, "java", null, null, null, null, null, custom, null, null, null, new Notifier());
+        Data d = new Data(environment, body, level, new Date(), null, platform, "java", null, null, null, null, null, custom, null, null, null, new Notifier());
         return new Payload(accessToken, d);
     }
 
@@ -66,7 +66,7 @@ public final class Payload implements JsonSerializable {
 
         Body body = Body.fromString(message, custom);
         String platform = System.getProperty("java.version");
-        Data d = new Data(environment, body, Level.WARNING, Instant.now(), null, platform, "java", null, null, null, null, null, null, null, null, null, new Notifier());
+        Data d = new Data(environment, body, Level.WARNING, new Date(), null, platform, "java", null, null, null, null, null, null, null, null, null, new Notifier());
         return new Payload(accessToken, d);
     }
 

--- a/src/main/java/com/rollbar/payload/data/Data.java
+++ b/src/main/java/com/rollbar/payload/data/Data.java
@@ -6,7 +6,7 @@ import com.rollbar.payload.utilities.InvalidLengthException;
 import com.rollbar.payload.utilities.JsonSerializable;
 import com.rollbar.payload.utilities.Validate;
 
-import java.time.Instant;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -66,8 +66,8 @@ public class Data implements JsonSerializable {
      * @throws ArgumentNullException if environment or body is null
      * @throws InvalidLengthException if environment or title is over 255 characters, or uuid is over 32 characters
      */
-    public Data(String environment, Body body, Level level, Instant timestamp, String codeVersion, String platform, String language, String framework, String context, Request request, Person person, Server server, Map<String, Object> custom, String fingerprint, String title, UUID uuid, Notifier notifier) throws ArgumentNullException, InvalidLengthException {
-        this(environment, body, level, timestamp == null ? null : timestamp.getEpochSecond(), codeVersion, platform, language, framework, context, request, person, server, custom, fingerprint, title, uuid == null ? null : uuid.toString().replace("-", ""), notifier);
+    public Data(String environment, Body body, Level level, Date timestamp, String codeVersion, String platform, String language, String framework, String context, Request request, Person person, Server server, Map<String, Object> custom, String fingerprint, String title, UUID uuid, Notifier notifier) throws ArgumentNullException, InvalidLengthException {
+        this(environment, body, level, timestamp == null ? null : (timestamp.getTime() / 1000), codeVersion, platform, language, framework, context, request, person, server, custom, fingerprint, title, uuid == null ? null : uuid.toString().replace("-", ""), notifier);
     }
 
     private Data(String environment, Body body, Level level, Long timestamp, String codeVersion, String platform, String language, String framework, String context, Request request, Person person, Server server, Map<String, Object> custom, String fingerprint, String title, String uuid, Notifier notifier) throws ArgumentNullException, InvalidLengthException {
@@ -153,8 +153,8 @@ public class Data implements JsonSerializable {
     /**
      * @return the moment the bug happened, visible in ui as client_timestamp
      */
-    public Instant timestamp() {
-        return this.timestamp == null ? null : Instant.ofEpochSecond(this.timestamp);
+    public Date timestamp() {
+        return this.timestamp == null ? null : new Date(this.timestamp * 1000);
     }
 
     /**
@@ -162,8 +162,8 @@ public class Data implements JsonSerializable {
     * @param date the moment the bug happened, visible in ui as client_timestamp
     * @return copy of this Data with date overridden
     */
-    public Data timestamp(Instant date) {
-        return new Data(environment, body, level, date == null ? null : date.getEpochSecond(), codeVersion, platform, language, framework, context, request, person, server, custom, fingerprint, title, uuid, notifier);
+    public Data timestamp(Date date) {
+        return new Data(environment, body, level, date == null ? null : (date.getTime() / 1000), codeVersion, platform, language, framework, context, request, person, server, custom, fingerprint, title, uuid, notifier);
     }
 
     /**

--- a/src/main/java/com/rollbar/payload/data/body/Body.java
+++ b/src/main/java/com/rollbar/payload/data/body/Body.java
@@ -2,6 +2,7 @@ package com.rollbar.payload.data.body;
 
 import com.rollbar.payload.utilities.ArgumentNullException;
 import com.rollbar.payload.utilities.JsonSerializable;
+import com.rollbar.payload.utilities.StringUtils;
 import com.rollbar.payload.utilities.Validate;
 
 import java.util.LinkedHashMap;
@@ -25,7 +26,7 @@ public class Body implements JsonSerializable {
     /**
      * Create a Body from an error with a human readable descriptpion. If {@link Throwable#getCause()} isn't null will
      * return a Trace Chain
-     * @param error the error to turn into a Body
+     * @param error       the error to turn into a Body
      * @param description the human readable description of the top level error in the chain (or the error itself if not
      *                    a chained error).
      * @return the Rollbar Body constructed from the error
@@ -63,7 +64,7 @@ public class Body implements JsonSerializable {
     /**
      * Create a Body from a string message and additional arguments
      * @param message the message to convert into a Rollbar Message
-     * @param extra the extra data to send to Rollbar
+     * @param extra   the extra data to send to Rollbar
      * @return a body containing a message containing this message body and extra arguments
      * @throws ArgumentNullException if message is null or whitespace
      */
@@ -167,6 +168,6 @@ public class Body implements JsonSerializable {
     }
 
     private static String toSnakeCase(String simpleName) {
-        return String.join("_", simpleName.split("(?=\\p{Lu})")).toLowerCase();
+        return StringUtils.join("_", simpleName.split("(?=\\p{Lu})")).toLowerCase();
     }
 }

--- a/src/main/java/com/rollbar/payload/utilities/Extensible.java
+++ b/src/main/java/com/rollbar/payload/utilities/Extensible.java
@@ -51,7 +51,7 @@ public abstract class Extensible<T extends Extensible<T>> implements JsonSeriali
      * @return null or the member at that key
      */
     public Object get(String name) {
-        return members.getOrDefault(name, null);
+        return members.get(name);
     }
 
     /**
@@ -115,8 +115,8 @@ public abstract class Extensible<T extends Extensible<T>> implements JsonSeriali
     public Map<String, Object> asJson() {
         LinkedHashMap<String, Object> json = new LinkedHashMap<String, Object>();
         for(String key : knownMembers()) {
-            if (this.members.containsKey(key) && this.members.getOrDefault(key, null) != null) {
-                json.put(key, this.members.getOrDefault(key, null));
+            if (this.members.containsKey(key) && this.members.get(key) != null) {
+                json.put(key, this.members.get(key));
             }
         }
         for(Map.Entry<String, Object> entry : this.members.entrySet()) {

--- a/src/main/java/com/rollbar/payload/utilities/StringUtils.java
+++ b/src/main/java/com/rollbar/payload/utilities/StringUtils.java
@@ -1,0 +1,32 @@
+package com.rollbar.payload.utilities;
+
+import java.util.Arrays;
+
+/**
+ * Some helper methods absent in Java 7
+ */
+public class StringUtils {
+    public static String join(CharSequence delimiter,
+                              Iterable<? extends CharSequence> elements) {
+        int length = 0;
+        for (CharSequence elem : elements) {
+            if(elem.length() == 0)
+                continue;
+            length += elem.length() + delimiter.length();
+        }
+        StringBuilder stb = new StringBuilder(length);
+        for (CharSequence elem : elements) {
+            if(elem.length() == 0)
+                continue;
+            stb.append(elem).append(delimiter);
+        }
+        if (stb.length() > 0)
+            stb.setLength(stb.length() - delimiter.length());
+        return stb.toString();
+    }
+
+    public static String join(String delimiter,
+                              String[] elements) {
+        return join(delimiter, Arrays.asList(elements));
+    }
+}

--- a/src/test/java/com/rollbar/TestThat.java
+++ b/src/test/java/com/rollbar/TestThat.java
@@ -1,6 +1,7 @@
 package com.rollbar;
 
 import com.rollbar.payload.utilities.Extensible;
+import com.rollbar.payload.utilities.StringUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -42,7 +43,6 @@ public class TestThat {
      * Returns a null string if not equivalent, or the differing item if they aren't.
      * @param beforeResult
      * @param afterResult
-     * @param <T>
      * @param <U>
      * @return null if equivalent, the difference if they aren't
      */
@@ -65,7 +65,7 @@ public class TestThat {
             intersect.retainAll(firstGetMap.keySet());
             exclusion.removeAll(intersect);
             if (!exclusion.isEmpty()) {
-                String missed = String.join(", ", exclusion);
+                String missed = StringUtils.join(", ", exclusion);
                 return String.format("Keys in map type mismatched, differ at: %s", missed);
             }
 
@@ -161,13 +161,13 @@ public class TestThat {
             fail("No differing fields!");
         }
         if (differingFields.size() > 1) {
-            fail(String.format("More than one field differs! (%s)", String.join(", ", differingFields)));
+            fail(String.format("More than one field differs! (%s)", StringUtils.join(", ", differingFields)));
         }
     }
 
     private static void addIfKeysDiffer(HashSet<String> differingFields, Map<String, Object> membersFirst, Map<String, Object> membersSecond, String key) {
-        Object one = membersFirst.getOrDefault(key, null);
-        Object two = membersSecond.getOrDefault(key, null);
+        Object one = membersFirst.get(key);
+        Object two = membersSecond.get(key);
         if (areDifferent(one, two)) {
             differingFields.add(key);
         }

--- a/src/test/java/com/rollbar/payload/data/DataTest.java
+++ b/src/test/java/com/rollbar/payload/data/DataTest.java
@@ -8,8 +8,7 @@ import com.rollbar.payload.utilities.InvalidLengthException;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -84,14 +83,14 @@ public class DataTest {
 
     @Test
     public void testTimestamp() throws Exception {
-        Instant one = Instant.ofEpochSecond(Instant.now().getEpochSecond());
-        Instant two = one.minus(7, ChronoUnit.DAYS);
-        TestThat.getAndSetWorks(d, one, two, new GetAndSet<Data, Instant>() {
-            public Instant get(Data data) {
+        Date one = new Date(System.currentTimeMillis() / 1000 * 1000);
+        Date two = new Date(one.getTime() - 7 * 24 * 60 * 60 * 1000);
+        TestThat.getAndSetWorks(d, one, two, new GetAndSet<Data, Date>() {
+            public Date get(Data data) {
                 return data.timestamp();
             }
 
-            public Data set(Data data, Instant val) {
+            public Data set(Data data, Date val) {
                 return data.timestamp(val);
             }
         });
@@ -301,6 +300,6 @@ public class DataTest {
 
     @Test
     public void testConstructor() throws Exception {
-        Data d = new Data("environment", Body.fromString("String"), Level.CRITICAL, Instant.now(), "version", "platform", "language", "framework", "CONTEXT", new Request(), new Person("ID"), new Server(), new LinkedHashMap<String, Object>(), "fingerprint", "title", UUID.randomUUID(), new Notifier());
+        Data d = new Data("environment", Body.fromString("String"), Level.CRITICAL, new Date(), "version", "platform", "language", "framework", "CONTEXT", new Request(), new Person("ID"), new Server(), new LinkedHashMap<String, Object>(), "fingerprint", "title", UUID.randomUUID(), new Notifier());
     }
 }


### PR DESCRIPTION
I fixed several places to make the plugin compatible with JDK 7. I believe it's important since Java 7 is still used in about half of all Java projects (https://plumbr.eu/blog/java/java-version-statistics-2015-edition). We're still working on Java 7 as well.

The most important differences are:
* I replaced **Instant** with **Date**. Since Rollbar expects timestamp in seconds, even Date will suffice.
* Added an implementation for **String.join**
* Replaced **getOrDefault** with **get**. All occurrences of getOrDefault used null as "default" parameter value. This means behavior didn't change if we replace it with a get method call. 
* Fixed JavaDoc in TestThat.java