### PR TITLE
Null handler test

### DIFF
--- a/rollbar/src/test/java/com/rollbar/RollbarTest.java
+++ b/rollbar/src/test/java/com/rollbar/RollbarTest.java
@@ -13,4 +13,10 @@ public class RollbarTest {
         assertEquals("some-access-token", rollbar.getAccessToken());
         assertEquals("some-environment", rollbar.getEnvironment());
     }
+
+    @Test
+    public void itDoesNotThrowANullPointerExceptionWhenLoggingAnException() {
+        Rollbar rollbar = new Rollbar("some-access-token", "some-environment");
+        rollbar.log(new Exception("some exception"));
+    }
 }


### PR DESCRIPTION
Exposes a null pointer exception when a handler has not been set for the response from the Rollbar server.

I'll clean up the branch history once the constructor null pointer has been merged.