### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/rollbar-payload/src/main/java/com/rollbar/payload/Payload.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/Payload.java
@@ -18,6 +18,24 @@ import java.util.Map;
  * successful when serialized and POSTed to the correct endpoint.
  */
 public final class Payload implements JsonSerializable {
+    private final String accessToken;
+    private final Data data;
+
+    /**
+     * Constructor
+     * @param accessToken An access token with scope "post_server_item" or "post_client_item". Probably "server" unless
+     *                    your {@link Data#platform()} is "android" or "client". Must not be null or whitespace.
+     * @param data The data to POST to Rollbar. Must not be null.
+     * @throws ArgumentNullException if either argument was null
+     */
+    public Payload(String accessToken, Data data) throws ArgumentNullException {
+        Validate.isNotNullOrWhitespace(accessToken, "accessToken");
+        this.accessToken = accessToken;
+
+        Validate.isNotNull(data, "data");
+        this.data = data;
+    }
+
     /**
      * A shortcut factory for creating a payload
      * @param accessToken not nullable, the server_post access token to send this payload to
@@ -55,24 +73,6 @@ public final class Payload implements JsonSerializable {
         String platform = System.getProperty("java.version");
         Data d = new Data(environment, body, Level.WARNING, new Date(), null, platform, "java", null, null, null, null, null, null, null, null, null, new Notifier());
         return new Payload(accessToken, d);
-    }
-
-    private final String accessToken;
-    private final Data data;
-
-    /**
-     * Constructor
-     * @param accessToken An access token with scope "post_server_item" or "post_client_item". Probably "server" unless
-     *                    your {@link Data#platform()} is "android" or "client". Must not be null or whitespace.
-     * @param data The data to POST to Rollbar. Must not be null.
-     * @throws ArgumentNullException if either argument was null
-     */
-    public Payload(String accessToken, Data data) throws ArgumentNullException {
-        Validate.isNotNullOrWhitespace(accessToken, "accessToken");
-        this.accessToken = accessToken;
-
-        Validate.isNotNull(data, "data");
-        this.data = data;
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/Request.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/Request.java
@@ -35,16 +35,6 @@ public class Request extends Extensible<Request> {
         Collections.addAll(Request.keys, keys);
     }
 
-    @Override
-    protected Set<String> getKnownMembers() {
-        return keys;
-    }
-
-    @Override
-    public Request copy() {
-        return new Request(getMembers());
-    }
-
     /**
      * Constructor
      * @param members map of custom arguments
@@ -104,6 +94,16 @@ public class Request extends Extensible<Request> {
         putKnown(POST_KEY, post == null ? null : new LinkedHashMap<String, Object>(post));
         putKnown(BODY_KEY, body);
         putKnown(USER_IP_KEY, userIp == null ? null : userIp.getHostAddress());
+    }
+
+    @Override
+    protected Set<String> getKnownMembers() {
+        return keys;
+    }
+
+    @Override
+    public Request copy() {
+        return new Request(getMembers());
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/Server.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/Server.java
@@ -16,18 +16,6 @@ public class Server extends Extensible<Server> {
     public static final String BRANCH_KEY = "branch";
     public static final String CODE_VERSION_KEY = "code_version";
 
-    @Override
-    protected Set<String> getKnownMembers() {
-        Set<String> result = new HashSet<String>(4);
-        Collections.addAll(result, HOST_KEY, ROOT_KEY, BRANCH_KEY, CODE_VERSION_KEY);
-        return result;
-    }
-
-    @Override
-    public Server copy() {
-        return new Server(getMembers());
-    }
-
     private Server(Map<String, Object> members) {
         super(members);
     }
@@ -64,6 +52,18 @@ public class Server extends Extensible<Server> {
         putKnown(ROOT_KEY, root);
         putKnown(BRANCH_KEY, branch);
         putKnown(CODE_VERSION_KEY, codeVersion);
+    }
+
+    @Override
+    protected Set<String> getKnownMembers() {
+        Set<String> result = new HashSet<String>(4);
+        Collections.addAll(result, HOST_KEY, ROOT_KEY, BRANCH_KEY, CODE_VERSION_KEY);
+        return result;
+    }
+
+    @Override
+    public Server copy() {
+        return new Server(getMembers());
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Body.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Body.java
@@ -12,6 +12,18 @@ import java.util.Map;
  * A container for the actual error(s), message, or crash report that caused this error.
  */
 public class Body implements JsonSerializable {
+    private final BodyContents contents;
+
+    /**
+     * Constructor
+     * @param contents the contents of this body (either Trace, TraceChain, Message, or CrashReport)
+     * @throws ArgumentNullException if contents is nul
+     */
+    public Body(BodyContents contents) throws ArgumentNullException {
+        Validate.isNotNull(contents, "contents");
+        this.contents = contents;
+    }
+
     /**
      * Create a Body from an error. If {@link Throwable#getCause()} isn't null will return a Trace Chain,
      * otherwise returns a Trace
@@ -82,18 +94,6 @@ public class Body implements JsonSerializable {
     public static Body fromCrashReportString(String raw) throws ArgumentNullException {
         final CrashReport contents = new CrashReport(raw);
         return new Body(contents);
-    }
-
-    private final BodyContents contents;
-
-    /**
-     * Constructor
-     * @param contents the contents of this body (either Trace, TraceChain, Message, or CrashReport)
-     * @throws ArgumentNullException if contents is nul
-     */
-    public Body(BodyContents contents) throws ArgumentNullException {
-        Validate.isNotNull(contents, "contents");
-        this.contents = contents;
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/ExceptionInfo.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/ExceptionInfo.java
@@ -11,30 +11,6 @@ import java.util.Map;
  * Represents *non-stacktrace* information about an exception, like class, description, and message.
  */
 public class ExceptionInfo implements JsonSerializable {
-    /**
-     * Create an exception info from a throwable.
-     * @param error the throwable
-     * @throws ArgumentNullException if the error is null
-     * @return an exception info with information gathered from the error
-     */
-    public static ExceptionInfo fromThrowable(Throwable error) throws ArgumentNullException {
-        return fromThrowable(error, null);
-    }
-
-    /**
-     * Create an exception info from an error and a (human readable) description of the error
-     * @param error the error
-     * @param description the human readable description of the error
-     * @throws ArgumentNullException if the error is null
-     * @return the ExceptionInfo built from the error and the description
-     */
-    public static ExceptionInfo fromThrowable(Throwable error, String description) throws ArgumentNullException {
-        Validate.isNotNull(error, "error");
-        String className = error.getClass().getSimpleName();
-        String message = error.getMessage();
-        return new ExceptionInfo(className, message, description);
-    }
-
     private final String className;
     private final String message;
     private final String description;
@@ -60,6 +36,30 @@ public class ExceptionInfo implements JsonSerializable {
         this.className = className;
         this.message = message;
         this.description = description;
+    }
+
+    /**
+     * Create an exception info from a throwable.
+     * @param error the throwable
+     * @throws ArgumentNullException if the error is null
+     * @return an exception info with information gathered from the error
+     */
+    public static ExceptionInfo fromThrowable(Throwable error) throws ArgumentNullException {
+        return fromThrowable(error, null);
+    }
+
+    /**
+     * Create an exception info from an error and a (human readable) description of the error
+     * @param error the error
+     * @param description the human readable description of the error
+     * @throws ArgumentNullException if the error is null
+     * @return the ExceptionInfo built from the error and the description
+     */
+    public static ExceptionInfo fromThrowable(Throwable error, String description) throws ArgumentNullException {
+        Validate.isNotNull(error, "error");
+        String className = error.getClass().getSimpleName();
+        String message = error.getMessage();
+        return new ExceptionInfo(className, message, description);
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
@@ -13,37 +13,6 @@ import java.util.Map;
  * Represents a single frame from a stack trace
  */
 public class Frame implements JsonSerializable {
-    /**
-     * Get an array of frames from an error
-     * @param error the error
-     * @return the frames representing the error's stack trace
-     * @throws ArgumentNullException if error is null
-     */
-    public static Frame[] fromThrowable(Throwable error) throws ArgumentNullException {
-        Validate.isNotNull(error, "error");
-        StackTraceElement[] elements = error.getStackTrace();
-        ArrayList<Frame> result = new ArrayList<Frame>();
-        for(StackTraceElement element : elements) {
-            result.add(fromStackTraceElement(element));
-        }
-        Collections.reverse(result);
-        return result.toArray(new Frame[result.size()]);
-    }
-
-    /**
-     * Get a Frame from a StackTraceElement
-     * @param stackTraceElement the StackTraceElement (a.k.a.: stack frame)
-     * @return the Frame representing the StackTraceElement
-     * @throws ArgumentNullException if stackTraceElement is null
-     */
-    public static Frame fromStackTraceElement(StackTraceElement stackTraceElement) throws ArgumentNullException {
-        String filename = stackTraceElement.getClassName() + ".java";
-        Integer lineNumber = stackTraceElement.getLineNumber();
-        String method = stackTraceElement.getMethodName();
-
-        return new Frame(filename, lineNumber, null, method, null, null, null, null);
-    }
-
     private final String filename;
     private final Integer lineNumber;
     private final Integer columnNumber;
@@ -84,6 +53,37 @@ public class Frame implements JsonSerializable {
         this.context = context;
         this.args = args == null ? null : args.clone();
         this.keywordArgs = keywordArgs == null ? null : new LinkedHashMap<String, Object>(keywordArgs);
+    }
+
+    /**
+     * Get an array of frames from an error
+     * @param error the error
+     * @return the frames representing the error's stack trace
+     * @throws ArgumentNullException if error is null
+     */
+    public static Frame[] fromThrowable(Throwable error) throws ArgumentNullException {
+        Validate.isNotNull(error, "error");
+        StackTraceElement[] elements = error.getStackTrace();
+        ArrayList<Frame> result = new ArrayList<Frame>();
+        for(StackTraceElement element : elements) {
+            result.add(fromStackTraceElement(element));
+        }
+        Collections.reverse(result);
+        return result.toArray(new Frame[result.size()]);
+    }
+
+    /**
+     * Get a Frame from a StackTraceElement
+     * @param stackTraceElement the StackTraceElement (a.k.a.: stack frame)
+     * @return the Frame representing the StackTraceElement
+     * @throws ArgumentNullException if stackTraceElement is null
+     */
+    public static Frame fromStackTraceElement(StackTraceElement stackTraceElement) throws ArgumentNullException {
+        String filename = stackTraceElement.getClassName() + ".java";
+        Integer lineNumber = stackTraceElement.getLineNumber();
+        String method = stackTraceElement.getMethodName();
+
+        return new Frame(filename, lineNumber, null, method, null, null, null, null);
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Message.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Message.java
@@ -14,18 +14,6 @@ import java.util.Set;
 public class Message extends Extensible<Message> implements BodyContents {
     public static final String BODY_KEY = "body";
 
-    @Override
-    protected Set<String> getKnownMembers() {
-        Set<String> result = new HashSet<String>(4);
-        result.add(BODY_KEY);
-        return result;
-    }
-
-    @Override
-    public Message copy() {
-        return new Message(getMembers());
-    }
-
     private Message(Map<String, Object> members) {
         super(members);
     }
@@ -49,6 +37,18 @@ public class Message extends Extensible<Message> implements BodyContents {
         super(members);
         Validate.isNotNullOrWhitespace(body, "body");
         putKnown(BODY_KEY, body);
+    }
+
+    @Override
+    protected Set<String> getKnownMembers() {
+        Set<String> result = new HashSet<String>(4);
+        result.add(BODY_KEY);
+        return result;
+    }
+
+    @Override
+    public Message copy() {
+        return new Message(getMembers());
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Trace.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Trace.java
@@ -11,6 +11,22 @@ import java.util.Map;
  * Represent a Stack Trace to send to Rollbar
  */
 public class Trace implements BodyContents, JsonSerializable {
+    private final Frame[] frames;
+    private final ExceptionInfo exception;
+
+    /**
+     * Constructor
+     * @param frames not nullable, frames making up the exception
+     * @param exception not nullable, info about the exception
+     * @throws ArgumentNullException if either argument is null
+     */
+    public Trace(Frame[] frames, ExceptionInfo exception) throws ArgumentNullException {
+        Validate.isNotNull(frames, "frames");
+        this.frames = frames.clone();
+        Validate.isNotNull(exception, "exception");
+        this.exception = exception;
+    }
+
     /**
      * Create a stack trace from a throwable
      * @param error the Throwable to create a stack trace from
@@ -35,22 +51,6 @@ public class Trace implements BodyContents, JsonSerializable {
         ExceptionInfo exceptionInfo = ExceptionInfo.fromThrowable(error, description);
 
         return new Trace(frames, exceptionInfo);
-    }
-
-    private final Frame[] frames;
-    private final ExceptionInfo exception;
-
-    /**
-     * Constructor
-     * @param frames not nullable, frames making up the exception
-     * @param exception not nullable, info about the exception
-     * @throws ArgumentNullException if either argument is null
-     */
-    public Trace(Frame[] frames, ExceptionInfo exception) throws ArgumentNullException {
-        Validate.isNotNull(frames, "frames");
-        this.frames = frames.clone();
-        Validate.isNotNull(exception, "exception");
-        this.exception = exception;
     }
 
     /**

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/TraceChain.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/TraceChain.java
@@ -11,6 +11,20 @@ import java.util.ArrayList;
  * Represents a chain of errors (typically from Exceptions with {@link Exception#getCause()} returning some value)
  */
 public class TraceChain implements BodyContents, JsonSerializable {
+    private final Trace[] traces;
+
+    /**
+     * Constructor
+     * @param traces the traces making up this trace chain
+     * @throws ArgumentNullException if traces are null
+     * @throws InvalidLengthException if there are no traces in the array
+     */
+    public TraceChain(Trace[] traces) throws ArgumentNullException, InvalidLengthException {
+        Validate.isNotNull(traces, "traces");
+        Validate.minLength(traces, 1, "traces");
+        this.traces = traces.clone();
+    }
+
     /**
      * Generate a TraceChain from a throwable with multiple causes
      * @param error the error to record
@@ -38,20 +52,6 @@ public class TraceChain implements BodyContents, JsonSerializable {
         } while(error != null);
         Trace[] traces = chain.toArray(new Trace[chain.size()]);
         return new TraceChain(traces);
-    }
-
-    private final Trace[] traces;
-
-    /**
-     * Constructor
-     * @param traces the traces making up this trace chain
-     * @throws ArgumentNullException if traces are null
-     * @throws InvalidLengthException if there are no traces in the array
-     */
-    public TraceChain(Trace[] traces) throws ArgumentNullException, InvalidLengthException {
-        Validate.isNotNull(traces, "traces");
-        Validate.minLength(traces, 1, "traces");
-        this.traces = traces.clone();
     }
 
     /**

--- a/rollbar-sender/src/main/java/com/rollbar/sender/PayloadSender.java
+++ b/rollbar-sender/src/main/java/com/rollbar/sender/PayloadSender.java
@@ -14,6 +14,9 @@ import java.util.regex.Pattern;
  * and the default implementation.
  */
 public class PayloadSender implements Sender {
+    private static final Pattern messagePattern = Pattern.compile("\"message\"\\s*:\\s*\"([^\"]*)\"");
+    private static final Pattern uuidPattern = Pattern.compile("\"uuid\"\\s*:\\s*\"([^\"]*)\"");
+
     /**
      * If you don't set the url this is the URL that gets used.
      */
@@ -84,9 +87,6 @@ public class PayloadSender implements Sender {
             handler.handleResponse(response);
         }
     }
-
-    private static final Pattern messagePattern = Pattern.compile("\"message\"\\s*:\\s*\"([^\"]*)\"");
-    private static final Pattern uuidPattern = Pattern.compile("\"uuid\"\\s*:\\s*\"([^\"]*)\"");
 
     private RollbarResponse readResponse(HttpURLConnection connection) throws ConnectionFailedException {
         int result;

--- a/rollbar-sender/src/main/java/com/rollbar/sender/RollbarResponse.java
+++ b/rollbar-sender/src/main/java/com/rollbar/sender/RollbarResponse.java
@@ -7,6 +7,11 @@ public class RollbarResponse {
     private final RollbarResponseCode statusCode;
     private final String result;
 
+    private RollbarResponse(RollbarResponseCode statusCode, String result) {
+        this.statusCode = statusCode;
+        this.result = result;
+    }
+
     /**
      * The static factory method for a successful post to Rollbar
      * @param uuid the occurrence id that will result from the POST
@@ -32,11 +37,6 @@ public class RollbarResponse {
      */
     public static RollbarResponse notSent() {
         return new RollbarResponse(RollbarResponseCode.Filtered, "Payload not sent, because it was filtered.");
-    }
-
-    private RollbarResponse(RollbarResponseCode statusCode, String result) {
-        this.statusCode = statusCode;
-        this.result = result;
     }
 
     /**

--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/Extensible.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/Extensible.java
@@ -9,6 +9,13 @@ import java.util.*;
  * @param <T> The extensible type itself.
  */
 public abstract class Extensible<T extends Extensible<T>> implements JsonSerializable {
+    private Set<String> knownMembers;
+
+    /**
+     * The LinkedHashMap containing all members.
+     */
+    private final TreeMap<String, Object> members;
+
     /**
      * Constructor
      * @param members the LinkedHashMap of all members already in this object
@@ -27,8 +34,6 @@ public abstract class Extensible<T extends Extensible<T>> implements JsonSeriali
      */
     protected abstract Set<String> getKnownMembers();
 
-    private Set<String> knownMembers;
-
     private Set<String> knownMembers() {
         if (knownMembers == null) {
             knownMembers = getKnownMembers();
@@ -39,11 +44,6 @@ public abstract class Extensible<T extends Extensible<T>> implements JsonSeriali
     private boolean isKnownMember(String name) {
         return knownMembers().contains(name);
     }
-
-    /**
-     * The LinkedHashMap containing all members.
-     */
-    private final TreeMap<String, Object> members;
 
     /**
      * Get the member, or null if not present.

--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/InvalidLengthException.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/InvalidLengthException.java
@@ -4,6 +4,11 @@ package com.rollbar.utilities;
  * An IllegalArgumentException indicating an argument that's too long or too short.
  */
 public class InvalidLengthException extends IllegalArgumentException {
+
+    private InvalidLengthException(String message) {
+        super(message);
+    }
+
     /**
      * Static Factory making an exception indicating an argument was passed that was too long.
      * @param parameter the parameter that was too long
@@ -26,7 +31,4 @@ public class InvalidLengthException extends IllegalArgumentException {
         return new InvalidLengthException(String.format(msgFmt, parameter, len));
     }
 
-    private InvalidLengthException(String message) {
-        super(message);
-    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat