### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/StringUtils.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/StringUtils.java
@@ -5,7 +5,12 @@ import java.util.Arrays;
 /**
  * Some helper methods absent in Java 7
  */
-public class StringUtils {
+public final class StringUtils {
+
+    private StringUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     public static String join(CharSequence delimiter,
                               Iterable<? extends CharSequence> elements) {
         int length = 0;

--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/Validate.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/Validate.java
@@ -3,7 +3,12 @@ package com.rollbar.utilities;
 /**
  * Validates arguments. Throws runtime exceptions when the validation fails.
  */
-public class Validate {
+public final class Validate {
+
+    private Validate() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     /**
      * Asserts that the String is not null or purely whitespace.
      * @param x the string to validate


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat