### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/rollbar-sender/src/main/java/com/rollbar/sender/PayloadSender.java
+++ b/rollbar-sender/src/main/java/com/rollbar/sender/PayloadSender.java
@@ -88,7 +88,7 @@ public class PayloadSender implements Sender {
     private static final Pattern messagePattern = Pattern.compile("\"message\"\\s*:\\s*\"([^\"]*)\"");
     private static final Pattern uuidPattern = Pattern.compile("\"uuid\"\\s*:\\s*\"([^\"]*)\"");
 
-    private RollbarResponse readResponse(HttpURLConnection connection) throws ConnectionFailedException {
+    private static RollbarResponse readResponse(HttpURLConnection connection) throws ConnectionFailedException {
         int result;
         String content;
         try {
@@ -160,7 +160,7 @@ public class PayloadSender implements Sender {
         }
     }
 
-    private void setJsonSendAndReceive(HttpURLConnection connection) {
+    private static void setJsonSendAndReceive(HttpURLConnection connection) {
         connection.setRequestProperty("Accept-Charset", "utf-8");
         connection.setRequestProperty("Content-Type", "application/json; charset=utf-8");
         connection.setRequestProperty("Accept", "application/json");

--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/RollbarSerializer.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/RollbarSerializer.java
@@ -85,15 +85,15 @@ public class RollbarSerializer implements JsonSerializer {
         }
     }
 
-    private void serializeNumber(StringBuilder builder, Number value) {
+    private static void serializeNumber(StringBuilder builder, Number value) {
         builder.append(value);
     }
 
-    private void serializeBoolean(StringBuilder builder, Boolean value) {
+    private static void serializeBoolean(StringBuilder builder, Boolean value) {
         builder.append(value ? "true" : "false");
     }
 
-    private void serializeNull(StringBuilder builder) {
+    private static void serializeNull(StringBuilder builder) {
         builder.append("null");
     }
 
@@ -113,7 +113,7 @@ public class RollbarSerializer implements JsonSerializer {
         builder.append(']');
     }
 
-    private Map<String, Object> asMap(Map value) {
+    private static Map<String, Object> asMap(Map value) {
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> obj = (Map<String, Object>) value;
@@ -130,13 +130,13 @@ public class RollbarSerializer implements JsonSerializer {
         }
     }
 
-    private void serializeString(StringBuilder builder, String str) {
+    private static void serializeString(StringBuilder builder, String str) {
         builder.append('"');
         builder.append(str.replace("\"", "\\\""));
         builder.append('"');
     }
 
-    private void indent(StringBuilder builder, int i) {
+    private static void indent(StringBuilder builder, int i) {
         for(int x = 0; x <= i; x++) {
             builder.append("  ");
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat