### PR TITLE
Frame json cleanup, and obfuscation fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ dependency to your pom file:
 <dependency>
   <groupId>com.rollbar</groupId>
    <artifactId>rollbar</artifactId>
-   <version>0.5.2</version>
+   <version>0.5.3</version>
 </dependency>
 </dependencies>
 ```
@@ -44,7 +44,7 @@ dependency to your pom file:
 ### Gradle
 
 ```groovy
-compile('com.rollbar:rollbar:0.5.2')
+compile('com.rollbar:rollbar:0.5.3')
 ```
 
 ## Usage

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <properties>
-    <rollbar.version>0.5.2</rollbar.version>
+    <rollbar.version>0.5.3</rollbar.version>
   </properties>
 
   <name>java-rollbar</name>

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Body.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Body.java
@@ -164,10 +164,6 @@ public class Body implements JsonSerializable {
     }
 
     private String key() {
-        return toSnakeCase(contents.getClass().getSimpleName());
-    }
-
-    private static String toSnakeCase(String simpleName) {
-        return StringUtils.join("_", simpleName.split("(?=\\p{Lu})")).toLowerCase();
+        return contents.getKeyName();
     }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/BodyContents.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/BodyContents.java
@@ -4,4 +4,5 @@ package com.rollbar.payload.data.body;
  * A marker interface for the contents of the rollbar body.
  */
 public interface BodyContents {
+    String getKeyName();
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/CrashReport.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/CrashReport.java
@@ -45,4 +45,8 @@ public class CrashReport implements BodyContents, JsonSerializable {
         obj.put("raw", raw());
         return obj;
     }
+
+    public String getKeyName() {
+        return "crash_report";
+    }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
@@ -217,22 +217,30 @@ public class Frame implements JsonSerializable {
 
     public Map<String, Object> asJson() {
         Map<String, Object> obj = new LinkedHashMap<String, Object>();
-        if (filename() != null)
-            obj.put("filename", filename());
-        if (lineNumber() != null)
-            obj.put("lineno", lineNumber());
-        if (columnNumber() != null)
-            obj.put("colno", columnNumber());
-        if (method() != null)
-            obj.put("method", method());
-        if (code() != null)
-            obj.put("code", code());
-        if (context() != null)
-            obj.put("context", context());
-        if (args() != null)
-            obj.put("args", args());
-        if (keywordArgs() != null)
-            obj.put("kwargs", keywordArgs());
+        String filename = filename();
+        if (filename != null)
+            obj.put("filename", filename);
+        Integer lineNumber = lineNumber();
+        if (lineNumber != null)
+            obj.put("lineno", lineNumber);
+        Integer columnNumber = columnNumber();
+        if (columnNumber != null)
+            obj.put("colno", columnNumber);
+        String method = method();
+        if (method != null)
+            obj.put("method", method);
+        String code = code();
+        if (code != null)
+            obj.put("code", code);
+        CodeContext context = context();
+        if (context != null)
+            obj.put("context", context);
+        Object[] args = args();
+        if (args != null)
+            obj.put("args", args);
+        Map<String, Object> keywordArgs = keywordArgs();
+        if (keywordArgs != null)
+            obj.put("kwargs", keywordArgs);
         return obj;
     }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
@@ -217,14 +217,22 @@ public class Frame implements JsonSerializable {
 
     public Map<String, Object> asJson() {
         Map<String, Object> obj = new LinkedHashMap<String, Object>();
-        obj.put("filename", filename());
-        obj.put("lineno", lineNumber());
-        obj.put("colno", columnNumber());
-        obj.put("method", method());
-        obj.put("code", code());
-        obj.put("context", context());
-        obj.put("args", args());
-        obj.put("kwargs", keywordArgs());
+        if (filename() != null)
+            obj.put("filename", filename());
+        if (lineNumber() != null)
+            obj.put("lineno", lineNumber());
+        if (columnNumber() != null)
+            obj.put("colno", columnNumber());
+        if (method() != null)
+            obj.put("method", method());
+        if (code() != null)
+            obj.put("code", code());
+        if (context() != null)
+            obj.put("context", context());
+        if (args() != null)
+            obj.put("args", args());
+        if (keywordArgs() != null)
+            obj.put("kwargs", keywordArgs());
         return obj;
     }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Frame.java
@@ -216,31 +216,34 @@ public class Frame implements JsonSerializable {
     }
 
     public Map<String, Object> asJson() {
+
         Map<String, Object> obj = new LinkedHashMap<String, Object>();
         String filename = filename();
+        Integer lineNumber = lineNumber();
+        Integer columnNumber = columnNumber();
+        String method = method();
+        String code = code();
+        CodeContext context = context();
+        Object[] args = args();
+        Map<String, Object> keywordArgs = keywordArgs();
+
         if (filename != null)
             obj.put("filename", filename);
-        Integer lineNumber = lineNumber();
         if (lineNumber != null)
             obj.put("lineno", lineNumber);
-        Integer columnNumber = columnNumber();
         if (columnNumber != null)
             obj.put("colno", columnNumber);
-        String method = method();
         if (method != null)
             obj.put("method", method);
-        String code = code();
         if (code != null)
             obj.put("code", code);
-        CodeContext context = context();
         if (context != null)
             obj.put("context", context);
-        Object[] args = args();
         if (args != null)
             obj.put("args", args);
-        Map<String, Object> keywordArgs = keywordArgs();
         if (keywordArgs != null)
             obj.put("kwargs", keywordArgs);
+
         return obj;
     }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Message.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Message.java
@@ -67,4 +67,8 @@ public class Message extends Extensible<Message> implements BodyContents {
     public Message body(String body) throws ArgumentNullException {
         return new Message(body, getMembers());
     }
+
+    public String getKeyName() {
+        return "message";
+    }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Trace.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/Trace.java
@@ -93,4 +93,8 @@ public class Trace implements BodyContents, JsonSerializable {
         obj.put("exception", exception());
         return obj;
     }
+
+    public String getKeyName() {
+        return "trace";
+    }
 }

--- a/rollbar-payload/src/main/java/com/rollbar/payload/data/body/TraceChain.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/data/body/TraceChain.java
@@ -75,4 +75,8 @@ public class TraceChain implements BodyContents, JsonSerializable {
     public Trace[] asJson() {
         return traces();
     }
+
+    public String getKeyName() {
+        return "trace_chain";
+    }
 }

--- a/rollbar-payload/src/test/java/com/rollbar/payload/data/body/FrameTest.java
+++ b/rollbar-payload/src/test/java/com/rollbar/payload/data/body/FrameTest.java
@@ -139,4 +139,17 @@ public class FrameTest {
             }
         });
     }
+
+    @Test
+    public void testEmptyValues() {
+        Frame frame = new Frame("foo.java");
+        Map<String, Object> json = frame.asJson();
+        assertFalse(json.containsKey("lineno"));
+        assertFalse(json.containsKey("colno"));
+        assertFalse(json.containsKey("method"));
+        assertFalse(json.containsKey("code"));
+        assertFalse(json.containsKey("context"));
+        assertFalse(json.containsKey("args"));
+        assertFalse(json.containsKey("kwargs"));
+    }
 }

--- a/rollbar/src/test/java/com/rollbar/RollbarTest.java
+++ b/rollbar/src/test/java/com/rollbar/RollbarTest.java
@@ -19,4 +19,10 @@ public class RollbarTest {
         Rollbar rollbar = new Rollbar("some-access-token", "some-environment");
         rollbar.log(new Exception("some exception"));
     }
+
+    @Test
+    public void sendItemToRollbar() {
+        Rollbar rollbar = new Rollbar("e3a49f757f86465097c000cb2de9de08", "testing");
+        rollbar.error(new Exception("this is a test exception")); // should not throw an exception
+    }
 }


### PR DESCRIPTION
If a customer is obfuscating their code, because of the reflection being used for BodyContents, the payload is invalid, this removes the reflection and cleans up the json payload a bit.