### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such…

### DIFF
--- a/rollbar-payload/src/main/java/com/rollbar/payload/Payload.java
+++ b/rollbar-payload/src/main/java/com/rollbar/payload/Payload.java
@@ -44,7 +44,7 @@ public final class Payload implements JsonSerializable {
      * @param custom any custom data to be sent (null is OK)
      * @return the payload
      */
-    public static Payload fromError(String accessToken, String environment, Throwable error, LinkedHashMap<String, Object> custom) {
+    public static Payload fromError(String accessToken, String environment, Throwable error, Map<String, Object> custom) {
         Validate.isNotNullOrWhitespace(accessToken, "accessToken");
         Validate.isNotNullOrWhitespace(environment, "environment");
         Validate.isNotNull(error, "error");
@@ -64,7 +64,7 @@ public final class Payload implements JsonSerializable {
      * @param custom any custom data to be sent (null is OK)
      * @return the payload
      */
-    public static Payload fromMessage(String accessToken, String environment, String message, LinkedHashMap<String, Object> custom) {
+    public static Payload fromMessage(String accessToken, String environment, String message, Map<String, Object> custom) {
         Validate.isNotNullOrWhitespace(accessToken, "accessToken");
         Validate.isNotNullOrWhitespace(environment, "environment");
         Validate.isNotNull(message, "message");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1319

Please let me know if you have any questions.

M-Ezzat