### PR TITLE
RollbarSerializer.serializeValue(). Default serialisation.

### DIFF
--- a/rollbar-payload/src/test/java/com/rollbar/payload/RollbarSerializerTest.java
+++ b/rollbar-payload/src/test/java/com/rollbar/payload/RollbarSerializerTest.java
@@ -106,6 +106,25 @@ public class RollbarSerializerTest {
         }
     }
 
+    @Test
+    public void TestCustomTypeSerialize() {
+        final CustomClass custom = new CustomClass();
+        final Message msg = new Message("customParams");
+        final Body body = new Body(msg.put("someParam", custom));
+        final Data data = new Data(environment, body);
+        final Payload payload = new Payload(accessToken, data);
+        final String json = new RollbarSerializer().serialize(payload);
+        final JsonObject parsed = (JsonObject) new JsonParser().parse(json);
+        assertEquals(
+            custom.toString(),
+            parsed
+                .getAsJsonObject("data")
+                .getAsJsonObject("body")
+                .getAsJsonObject("message")
+                .getAsJsonPrimitive("someParam").getAsString()
+        );
+    }
+
     public Throwable getError() {
         try {
             throwException();
@@ -133,6 +152,17 @@ public class RollbarSerializerTest {
             throwException();
         } catch (Exception e) {
             throw new Exception("Wrapper Exception", e);
+        }
+    }
+
+    /**
+     * Class which is used for checking custom classes serialization.
+     */
+    public class CustomClass {
+
+        @Override
+        public String toString() {
+            return "custom string representation";
         }
     }
 }

--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/RollbarSerializer.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/RollbarSerializer.java
@@ -82,7 +82,13 @@ public class RollbarSerializer implements JsonSerializer {
         }
         else if (value instanceof Object[]) {
             serializeArray(builder, (Object[]) value, level);
+        } else {
+            serializeDefault(builder, value);
         }
+    }
+
+    private static void serializeDefault(StringBuilder builder, Object value) {
+        builder.append(String.format("\"%s\"", value));
     }
 
     private static void serializeNumber(StringBuilder builder, Number value) {


### PR DESCRIPTION
Hello guys!
Thanks a lot for the library, it is really helpful. 
I wanted to use exception as a custom parameter. Something like:
```
Rollbar rollbar = ...
Exception ex = ...
...................
Map<String, Object> custom = new HashMap<String, Object>();
custom.put("exception", ex)
rollbar.error("Some message", custom);
``` 
I faced the problem: my request failed because the JSON in the request was invalid.

I implemented workaround in my software, but once I already spent some time looking into your code I've decided to suggest the fix :) In my opinion, this serialiser should not produce invalid JSON. I see two ways of  how to avoid invalid JSON: 
1. Just throw an exception if something can not be serialised. In another words, force client to implement serialisation for the classes which ```com.rollbar.utilities.RollbarSerializer```can not serialise. Client always can implement ```com.rollbar.utilities.JsonSerializable``` for his classes. 
2. Implement default serialisation. So, any class will be somehow serialised. 

I liked the second option more and implemented it. The implementation is in this PR. 

Bye! 
