### PR TITLE
RollbarSerializer.serializeValue() Throwables serialisation

### DIFF
--- a/rollbar-payload/src/test/java/com/rollbar/payload/RollbarSerializerTest.java
+++ b/rollbar-payload/src/test/java/com/rollbar/payload/RollbarSerializerTest.java
@@ -127,7 +127,7 @@ public class RollbarSerializerTest {
         assertTrue(stacktrace.contains("Caused by: java.lang.RuntimeException"));
     }
 
-    public Throwable getError() {
+    private Throwable getError() {
         try {
             throwException();
             return null;
@@ -140,7 +140,7 @@ public class RollbarSerializerTest {
         throw new Exception("Non Chained Exception");
     }
 
-    public Throwable getChainedError() {
+    private Throwable getChainedError() {
         try {
             throwChainedError();
             return null;
@@ -149,7 +149,7 @@ public class RollbarSerializerTest {
         }
     }
 
-    public void throwChainedError() throws Exception {
+    private void throwChainedError() throws Exception {
         try {
             throwException();
         } catch (Exception e) {

--- a/rollbar-payload/src/test/java/com/rollbar/payload/RollbarSerializerTest.java
+++ b/rollbar-payload/src/test/java/com/rollbar/payload/RollbarSerializerTest.java
@@ -106,6 +106,27 @@ public class RollbarSerializerTest {
         }
     }
 
+    /**
+     * Check that Throwables are serialised as their stacktrace.
+     */
+    @Test
+    public void TestThrowableSerialize() {
+        final Exception exception = new Exception(new RuntimeException());
+        final Message msg = new Message("Message").put("exception", exception);
+        final Body body = new Body(msg);
+        final Data data = new Data(environment, body);
+        final String json = new RollbarSerializer(false).serialize(new Payload(accessToken, data));
+        final JsonObject parsed = (JsonObject) new JsonParser().parse(json);
+        final String stacktrace = parsed
+            .getAsJsonObject("data")
+            .getAsJsonObject("body")
+            .getAsJsonObject("message")
+            .getAsJsonPrimitive("exception").getAsString();
+        assertTrue(stacktrace.startsWith("java.lang.Exception: java.lang.RuntimeException"));
+        assertTrue(stacktrace.contains(getClass().getCanonicalName()));
+        assertTrue(stacktrace.contains("Caused by: java.lang.RuntimeException"));
+    }
+
     public Throwable getError() {
         try {
             throwException();

--- a/rollbar-utilities/src/main/java/com/rollbar/utilities/RollbarSerializer.java
+++ b/rollbar-utilities/src/main/java/com/rollbar/utilities/RollbarSerializer.java
@@ -1,5 +1,7 @@
 package com.rollbar.utilities;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.*;
 
 /**
@@ -83,6 +85,15 @@ public class RollbarSerializer implements JsonSerializer {
         else if (value instanceof Object[]) {
             serializeArray(builder, (Object[]) value, level);
         }
+        else if (value instanceof Throwable) {
+            serializeThrowable(builder, (Throwable) value);
+        }
+    }
+
+    private static void serializeThrowable(StringBuilder builder, Throwable value) {
+        final StringWriter writer = new StringWriter();
+        value.printStackTrace(new PrintWriter(writer));
+        builder.append(String.format("\"%s\"", writer.toString()));
     }
 
     private static void serializeNumber(StringBuilder builder, Number value) {


### PR DESCRIPTION
Hello guys again! :)
I've already told you about my problem with exceptions serialisation in #42, where I added default serialisation logic. In this pull request I added serialisation particularly for `Throwable`. 
Let me know what do you think about such a fix :)

Bye!  