### PR TITLE
Documentation update after moving HTTP to Sender module

### DIFF
--- a/rollbar/README.md
+++ b/rollbar/README.md
@@ -102,9 +102,10 @@ public class MyClass {
             this.monitoredMethod();
         } catch (Throwable t) {
             Payload p = Payload.fromError(SERVER_POST_ACCESS_TOKEN, ENVIRONMENT, t, null);
+            PayloadSender ps = new PayloadSender();
             try {
                 // Here you can filter or transform the payload as needed before sending it
-                p.send();
+                ps.send(p);
             } catch (ConnectionFailedException e) {
                 Logger.getLogger(MyClass.class.getName()).severe(p.toJson());
             }
@@ -128,9 +129,10 @@ public class Program {
         Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             public void uncaughtException(Thread t, Throwable e) {
                 Payload p = Payload.fromError(SERVER_POST_ACCESS_TOKEN, ENVIRONMENT, t, null);
+                PayloadSender ps = new PayloadSender();
                 try {
                     // Here you can filter or transform the payload as needed before sending it
-                    p.send();
+                    ps.send(p);
                 } catch (ConnectionFailedException e) {
                     Logger.getLogger(MyClass.class.getName()).severe(p.toJson());
                 }


### PR DESCRIPTION
Hello Rollbar team,

I am just new using Rollbar (specially on vanilla Java). I had to integrate you lib with a logger and, therefore, use what you say 'Custom usage'. I saw myself trying to sent a Payload ```p.send()``` unsuccessfully. After some digging into your code I realized that you moved HTTP to sender module. Thus, sending a Payload changed slightly. 

Since documentation wasn't updated accordingly, I decided to send you guys a PR approaching it. I thing this is useful for developers to be updated.