### PR TITLE
Add publishing with maven-publish plugin and signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,8 @@
-//plugins {
-//    id 'digital.wup.android-maven-publish' version '3.0.0' apply false
-//}
-
-def isReleaseBuild() {
-    return !VERSION_NAME.contains("SNAPSHOT")
-}
-
-def getReleaseRepositoryUrl() {
-    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-}
-
-def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
-}
-
-def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
+apply from: "$rootDir/gradle/release.gradle"
 
 subprojects {
     if (!it.name.contains('android')) {
         apply plugin: 'java'
-        apply plugin: 'maven-publish'
 
         apply from: "$rootDir/gradle/quality.gradle"
 
@@ -42,99 +17,6 @@ subprojects {
                         "Implementation-Version": VERSION_NAME
                 )
             }
-        }
-    }
-
-//    if(!it.name.startsWith('examples') && it.name.contains('android')) {
-//        apply plugin: 'digital.wup.android-maven-publish'
-//
-//        publishing {
-//            publications {
-//                mavenAar(MavenPublication) {
-//                    println components
-//                    //from components.android
-//                }
-//            }
-//        }
-//    }
-
-    if(!it.name.startsWith('examples') && !it.name.contains('android')) {
-        apply plugin: 'maven'
-        apply plugin: 'signing'
-
-        publishing {
-            task sourcesJar(type: Jar, dependsOn: classes) {
-                classifier = 'sources'
-                from sourceSets.main.allSource
-            }
-
-            task javadocJar(type: Jar, dependsOn: javadoc) {
-                classifier = 'javadoc'
-                from javadoc.destinationDir
-            }
-
-            publications {
-                maven(MavenPublication) {
-                    groupId GROUP
-                    version VERSION_NAME
-
-                    artifact sourcesJar
-                    artifact javadocJar
-                    from components.java
-                }
-            }
-        }
-
-        uploadArchives {
-            repositories {
-                mavenDeployer {
-                    beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-                    pom.groupId = GROUP
-                    pom.artifactId = POM_ARTIFACT_ID
-                    pom.version = VERSION_NAME
-
-                    repository(url: getReleaseRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                    }
-
-                    pom.project {
-                        name POM_NAME
-                        packaging POM_PACKAGING
-                        description POM_DESCRIPTION
-                        url POM_URL
-
-                        scm {
-                            url POM_SCM_URL
-                            connection POM_SCM_CONNECTION
-                            developerConnection POM_SCM_DEV_CONNECTION
-                        }
-
-                        licenses {
-                            license {
-                                name POM_LICENCE_NAME
-                                url POM_LICENCE_URL
-                                distribution POM_LICENCE_DIST
-                            }
-                        }
-
-                        developers {
-                            developer {
-                                id POM_DEVELOPER_ID
-                                name POM_DEVELOPER_NAME
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        signing {
-            required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-            sign configurations.archives
         }
     }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -134,8 +134,8 @@ subprojects {
 
             publishing {
                 task androidSourcesJar(type: Jar) {
-                    classifier = 'sources'
                     from android.sourceSets.main.java.srcDirs
+                    classifier = 'sources'
                 }
 
                 task androidJavadocs(type: Javadoc) {
@@ -149,16 +149,32 @@ subprojects {
                     from androidJavadocs.destinationDir
                 }
 
-                //android.libraryVariants
+                task androidClassJar(type: Jar) {
+                    from 'build/intermediates/classes/release/'
+                }
+
+                android.libraryVariants
                 publications {
                     jar(MavenPublication) {
                         groupId GROUP
                         version VERSION_NAME
 
-                        artifact androidSourcesJar
-                        artifact androidJavadocsJar
+                        artifact bundleRelease
+                        artifacts {
+                            archives androidClassJar
+                            archives androidSourcesJar
+                            archives androidJavadocsJar
+                        }
+
 
                         pom.withXml {
+                            def dependencies = asNode().appendNode('dependencies')
+                            configurations.compile.allDependencies.each {
+                                def dependency = dependencies.appendNode('dependency')
+                                dependency.appendNode('groupId', GROUP)
+                                dependency.appendNode('artifactId', it.name)
+                                dependency.appendNode('version', VERSION_NAME)
+                            }
                             asNode().children().last() + {
                                 resolveStrategy = Closure.DELEGATE_FIRST
                                 name POM_NAME
@@ -208,7 +224,12 @@ subprojects {
                                     } else {
                                         classifier = null
                                     }
-                                    extension = 'jar.asc'
+                                    def isAar = it.file =~ /\.aar\.asc$/
+                                    if (isAar.find()) {
+                                        extension = 'aar.asc'
+                                    } else {
+                                        extension = 'jar.asc'
+                                    }
                                 }
                             }
                         }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -16,8 +16,6 @@ subprojects {
             pomFile = file("${project.buildDir}/generated-pom.xml")
         }
 
-
-
         publishing {
             task sourcesJar(type: Jar, dependsOn: classes) {
                 classifier = 'sources'
@@ -116,6 +114,129 @@ subprojects {
             }
         }
     }
+
+    if (!it.project.parent.name.equals("examples") &&
+                it.name.contains('android') &&
+                !it.name.contains('examples')) {
+
+            apply plugin: 'maven-publish'
+            apply plugin: 'signing'
+
+            signing {
+                required true
+                sign configurations.archives
+            }
+
+            // pom file name
+            ext {
+                pomFile = file("${project.buildDir}/generated-pom.xml")
+            }
+
+            publishing {
+                task androidSourcesJar(type: Jar) {
+                    classifier = 'sources'
+                    from android.sourceSets.main.java.srcDirs
+                }
+
+                task androidJavadocs(type: Javadoc) {
+                    source = android.sourceSets.main.java.srcDirs
+                    classpath += configurations.compile
+                    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+                }
+
+                task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+                    classifier = 'javadoc'
+                    from androidJavadocs.destinationDir
+                }
+
+                //android.libraryVariants
+                publications {
+                    jar(MavenPublication) {
+                        groupId GROUP
+                        version VERSION_NAME
+
+                        artifact androidSourcesJar
+                        artifact androidJavadocsJar
+
+                        pom.withXml {
+                            asNode().children().last() + {
+                                resolveStrategy = Closure.DELEGATE_FIRST
+                                name POM_NAME
+                                description POM_DESCRIPTION
+
+                                url POM_URL
+                                scm {
+                                    url POM_SCM_URL
+                                    connection POM_SCM_CONNECTION
+                                    developerConnection POM_SCM_DEV_CONNECTION
+                                }
+                                licenses {
+                                    license {
+                                        name POM_LICENCE_NAME
+                                        url POM_LICENCE_URL
+                                        distribution POM_LICENCE_DIST
+                                    }
+                                }
+                                developers {
+                                    developer {
+                                        id POM_DEVELOPER_ID
+                                        name POM_DEVELOPER_NAME
+                                    }
+                                }
+                            }
+                        }
+
+                        // Sign the pom.xml and artifacts.
+                        if (signing.required) {
+                            // Sign the pom.xml.
+                            pom.withXml {
+                                writeTo(project.ext.pomFile)
+                                def pomAscFile = signing.sign(project.ext.pomFile).signatureFiles[0]
+                                artifact(pomAscFile) {
+                                    classifier = null
+                                    extension = 'pom.asc'
+                                }
+                                project.ext.pomFile.delete()
+                            }
+
+                            // Sign the artifacts.
+                            project.tasks.signArchives.signatureFiles.each {
+                                artifact(it) {
+                                    def matcher = it.file =~ /-(sources|javadoc)\.jar\.asc$/
+                                    if (matcher.find()) {
+                                        classifier = matcher.group(1)
+                                    } else {
+                                        classifier = null
+                                    }
+                                    extension = 'jar.asc'
+                                }
+                            }
+                        }
+
+                        repositories {
+                            def repoUrl = ""
+                            if (isReleaseBuild()) {
+                                repoUrl = getReleaseRepositoryUrl()
+                            } else {
+                                repoUrl = getSnapshotRepositoryUrl()
+                            }
+                            maven {
+                                url repoUrl
+                            }
+                        }
+                    }
+                }
+            }
+
+            model {
+                tasks.publishJarPublicationToMavenLocal {
+                    dependsOn(project.tasks.signArchives)
+                }
+                tasks.publishJarPublicationToMavenRepository {
+                    dependsOn(project.tasks.signArchives)
+                }
+            }
+        }
 }
 
 def isReleaseBuild() {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,0 +1,141 @@
+subprojects {
+    if (!it.project.parent.name.equals("examples") &&
+            !it.name.contains('android') &&
+            !it.name.contains('examples')) {
+
+        apply plugin: 'maven-publish'
+        apply plugin: 'signing'
+
+        signing {
+            required true
+            sign configurations.archives
+        }
+
+        // pom file name
+        ext {
+            pomFile = file("${project.buildDir}/generated-pom.xml")
+        }
+
+
+
+        publishing {
+            task sourcesJar(type: Jar, dependsOn: classes) {
+                classifier = 'sources'
+                from sourceSets.main.allSource
+            }
+
+            task javadocJar(type: Jar, dependsOn: javadoc) {
+                classifier = 'javadoc'
+                from javadoc.destinationDir
+            }
+
+            publications {
+                jar(MavenPublication) {
+                    groupId GROUP
+                    version VERSION_NAME
+
+                    artifact sourcesJar
+                    artifact javadocJar
+                    from components.java
+
+                    pom.withXml {
+                        asNode().children().last() + {
+                            resolveStrategy = Closure.DELEGATE_FIRST
+                            name POM_NAME
+                            description POM_DESCRIPTION
+                            url POM_URL
+                            scm {
+                                url POM_SCM_URL
+                                connection POM_SCM_CONNECTION
+                                developerConnection POM_SCM_DEV_CONNECTION
+                            }
+                            licenses {
+                                license {
+                                    name POM_LICENCE_NAME
+                                    url POM_LICENCE_URL
+                                    distribution POM_LICENCE_DIST
+                                }
+                            }
+                            developers {
+                                developer {
+                                    id POM_DEVELOPER_ID
+                                    name POM_DEVELOPER_NAME
+                                }
+                            }
+                        }
+                    }
+
+                    // Sign the pom.xml and artifacts.
+                    if (signing.required) {
+                        // Sign the pom.xml.
+                        pom.withXml {
+                            writeTo(project.ext.pomFile)
+                            def pomAscFile = signing.sign(project.ext.pomFile).signatureFiles[0]
+                            artifact(pomAscFile) {
+                                classifier = null
+                                extension = 'pom.asc'
+                            }
+                            project.ext.pomFile.delete()
+                        }
+
+                        // Sign the artifacts.
+                        project.tasks.signArchives.signatureFiles.each {
+                            artifact(it) {
+                                def matcher = it.file =~ /-(sources|javadoc)\.jar\.asc$/
+                                if (matcher.find()) {
+                                    classifier = matcher.group(1)
+                                } else {
+                                    classifier = null
+                                }
+                                extension = 'jar.asc'
+                            }
+                        }
+                    }
+
+                    repositories {
+                        def repoUrl = ""
+                        if (isReleaseBuild()) {
+                            repoUrl = getReleaseRepositoryUrl()
+                        } else {
+                            repoUrl = getSnapshotRepositoryUrl()
+                        }
+                        maven {
+                            url repoUrl
+                        }
+                    }
+                }
+            }
+        }
+
+        model {
+            tasks.publishJarPublicationToMavenLocal {
+                dependsOn(project.tasks.signArchives)
+            }
+            tasks.publishJarPublicationToMavenRepository {
+                dependsOn(project.tasks.signArchives)
+            }
+        }
+    }
+}
+
+def isReleaseBuild() {
+    return !VERSION_NAME.contains("SNAPSHOT")
+}
+
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}

--- a/rollbar-android/gradle.properties
+++ b/rollbar-android/gradle.properties
@@ -1,3 +1,0 @@
-POM_NAME=rollbar-android
-POM_ARTIFACT_ID=rollbar-android
-POM_PACKAGING=aar

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -758,24 +758,45 @@ public class Rollbar {
   }
 
   /**
-   * Old API
+   * report an exception to Rollbar
+   * @param throwable the exception that occurred.
    */
-
   @Deprecated
   public static void reportException(Throwable throwable) {
     reportException(throwable, null, null, null);
   }
 
+  /**
+   * report an exception to Rollbar, specifying the level.
+   *
+   * @param throwable the exception that occurred.
+   * @param level the severity level.
+   */
   @Deprecated
   public static void reportException(final Throwable throwable, final String level) {
     reportException(throwable, level, null, null);
   }
 
+  /**
+   * report an exception to Rollbar, specifying the level, and adding a custom description.
+   * @param throwable the exception that occurred.
+   * @param level the severity level.
+   * @param description the extra description.
+   */
   @Deprecated
   public static void reportException(final Throwable throwable, final String level, final String description) {
     reportException(throwable, level, description, null);
   }
 
+  /**
+   * report an exception to Rollbar, specifying the level, adding a custom description,
+   * and including extra data.
+   *
+   * @param throwable the exception that occurred.
+   * @param level the severity level.
+   * @param description the extra description.
+   * @param params the extra custom data.
+   */
   @Deprecated
   public static void reportException(final Throwable throwable, final String level, final String description, final Map<String, String> params) {
     ensureInit(new Runnable() {
@@ -786,16 +807,34 @@ public class Rollbar {
     });
   }
 
+  /**
+   * Report a message to Rollbar.
+   *
+   * @param message the message to send.
+   */
   @Deprecated
   public static void reportMessage(String message) {
     reportMessage(message, null);
   }
 
+  /**
+   * Report a message to Rollbar, specifying the level.
+   *
+   * @param message the message to send.
+   * @param level the severity level.
+   */
   @Deprecated
   public static void reportMessage(final String message, final String level) {
     reportMessage(message, level, null);
   }
 
+  /**
+   * Report a message to Rollbar, specifying the level, and including extra data.
+   *
+   * @param message the message to send.
+   * @param level the severity level.
+   * @param params the extra data.
+   */
   @Deprecated
   public static void reportMessage(final String message, final String level, final Map<String, String> params) {
     ensureInit(new Runnable() {

--- a/rollbar-api/gradle.properties
+++ b/rollbar-api/gradle.properties
@@ -1,3 +1,0 @@
-POM_NAME=rollbar-api
-POM_ARTIFACT_ID=rollbar-api
-POM_PACKAGING=jar

--- a/rollbar-java/gradle.properties
+++ b/rollbar-java/gradle.properties
@@ -1,3 +1,0 @@
-POM_NAME=rollbar-java
-POM_ARTIFACT_ID=rollbar-java
-POM_PACKAGING=jar

--- a/rollbar-web/gradle.properties
+++ b/rollbar-web/gradle.properties
@@ -1,3 +1,0 @@
-POM_NAME=rollbar-web
-POM_ARTIFACT_ID=rollbar-web
-POM_PACKAGING=jar


### PR DESCRIPTION
I think I managed to setup the `maven-publish` plugin with `signing` getting rid of the `maven` one. 

I've created a `gradle/release.gradle` where I moved all this logic and also removed all those `gradle.properties` files.

Now if you execute `./gradlew publishToMavenLocal` you could see how everything will be layout in the repo, and for uploading the archives I think that you should execute `./gradlew publish` plugin if you have set up all the things needed like credentials of the repository and the ones for signing.

@rokob Have in mind that this not publish the `rollbar-android`, maybe another way to publish it is required.

Test it before merge because maybe I broke something regarding the `rollbar-android`.