### PR TITLE
Stop adding the jar.asc to the build for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To report problems or ask a question about the beta release, please [create an i
 ## Installation
 
 ```groovy
-compile('com.rollbar:rollbar-java:1.0.0-beta-2')
+compile('com.rollbar:rollbar-java:1.0.0-beta-3')
 ```
 
 ## Upgrading from 0.5.4 or earlier to 1.0.0
@@ -158,7 +158,7 @@ dependency to your pom file:
 <dependency>
   <groupId>com.rollbar</groupId>
    <artifactId>rollbar-java</artifactId>
-   <version>1.0.0-beta-2</version>
+   <version>1.0.0-beta-3</version>
 </dependency>
 </dependencies>
 ```
@@ -166,7 +166,7 @@ dependency to your pom file:
 ### Gradle
 
 ```groovy
-compile('com.rollbar:rollbar-java:1.0.0-beta-2')
+compile('com.rollbar:rollbar-java:1.0.0-beta-3')
 ```
 
 ## Usage

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.0-beta-2
+VERSION_NAME=1.0.0-beta-3
 GROUP=com.rollbar
 
 POM_DESCRIPTION=For connecting your applications built on the JVM to Rollbar for Error Reporting

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -171,13 +171,11 @@ subprojects {
 
                         artifact bundleRelease
                         artifacts {
-                            archives androidClassJar
                             archives androidSourcesJar
                             archives androidJavadocsJar
                         }
                         artifact androidSourcesJar
                         artifact androidJavadocsJar
-
 
                         pom.withXml {
                             def dependencies = asNode().appendNode('dependencies')

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class Rollbar {
-  private static final String NOTIFIER_VERSION = "1.0.0-beta-2";
+  private static final String NOTIFIER_VERSION = "1.0.0-beta-3";
   private static final String ITEM_DIR_NAME = "rollbar-items";
   private static final String ANDROID = "android";
   private static final String DEFAULT_ENVIRONMENT = "production";


### PR DESCRIPTION
This means we should be publishing the aar and it should get picked up automatically. Also bump the version number to beta-3