### PR TITLE
if the get query param list has only one element then hoist the element out of the list

### DIFF
--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
@@ -126,7 +126,7 @@ public class Request implements JsonSerializable {
       values.put("params", params);
     }
     if (get != null) {
-      values.put("get", get);
+      values.put("get", processGetParams(get));
     }
     if (queryString != null) {
       values.put("query_string", queryString);
@@ -142,6 +142,20 @@ public class Request implements JsonSerializable {
     }
 
     return values;
+  }
+
+  private Map<String, Object> processGetParams(Map<String, List<String>> map) {
+    Map<String, Object> result = new HashMap<>();
+    for (Map.Entry<String, List<String>> entry : map.entrySet()) {
+      String k = entry.getKey();
+      List<String> v = entry.getValue();
+      if (v.size() == 1) {
+        result.put(k, v.get(0));
+      } else {
+        result.put(k, v);
+      }
+    }
+    return result;
   }
 
   @Override

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/RequestTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/RequestTest.java
@@ -1,11 +1,14 @@
 package com.rollbar.api.payload.data;
 
+import static java.util.Arrays.asList;
+
 import static com.rollbar.test.Factory.request;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import org.junit.Test;
 
 public class RequestTest {
@@ -20,7 +23,14 @@ public class RequestTest {
 
   @Test
   public void shouldReturnAsJson() {
-    Request request = request();
+    Map<String, List<String>> get = new HashMap<>();
+    get.put("param1", asList("value1.1", "value1.2"));
+    get.put("param2", asList("value2.1"));
+    Map<String, Object> expectedGet = new HashMap<>();
+    expectedGet.put("param1", get.get("param1"));
+    expectedGet.put("param2", "value2.1");
+
+    Request request = request(get);
 
     Map<String, Object> expected = new HashMap<>();
 
@@ -34,7 +44,7 @@ public class RequestTest {
       expected.put("params", request.getParams());
     }
     if (request.getGet() != null) {
-      expected.put("get", request.getGet());
+      expected.put("get", expectedGet);
     }
     if (request.getQueryString() != null) {
       expected.put("query_string", request.getQueryString());

--- a/rollbar-api/src/test/java/com/rollbar/test/Factory.java
+++ b/rollbar-api/src/test/java/com/rollbar/test/Factory.java
@@ -133,13 +133,17 @@ public class Factory {
   }
 
   public static Request request() {
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Accept", "text/html");
-    headers.put("Referer", "https://rollbar.com/");
-
     Map<String, List<String>> get = new HashMap<>();
     get.put("param1", asList("value1.1", "value1.2"));
     get.put("param2", asList("value2.1"));
+
+    return request(get);
+  }
+
+  public static Request request(Map<String, List<String>> get) {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Accept", "text/html");
+    headers.put("Referer", "https://rollbar.com/");
 
     return new Request.Builder()
         .url("https://rollbar.com/project/1")


### PR DESCRIPTION
fixes #89 