### PR TITLE
Support whether data comes from an uncaught exception or not

### DIFF
--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Data.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Data.java
@@ -45,6 +45,8 @@ public class Data implements JsonSerializable {
 
   private final String uuid;
 
+  private final boolean isUncaught;
+
   private final Notifier notifier;
 
   private Data(Builder builder) {
@@ -65,6 +67,7 @@ public class Data implements JsonSerializable {
     this.fingerprint = builder.fingerprint;
     this.title = builder.title;
     this.uuid = builder.uuid;
+    this.isUncaught = builder.isUncaught;
     this.notifier = builder.notifier;
   }
 
@@ -224,6 +227,15 @@ public class Data implements JsonSerializable {
   /**
    * Getter.
    *
+   * @return whether or not this data comes from an uncaught exception
+   */
+  public boolean isUncaught() {
+    return isUncaught;
+  }
+
+  /**
+   * Getter.
+   *
    * @return the notifier.
    */
   public Notifier getNotifier() {
@@ -319,6 +331,7 @@ public class Data implements JsonSerializable {
         && Objects.equals(fingerprint, data.fingerprint)
         && Objects.equals(title, data.title)
         && Objects.equals(uuid, data.uuid)
+        && isUncaught == data.isUncaught
         && Objects.equals(notifier, data.notifier);
   }
 
@@ -326,7 +339,7 @@ public class Data implements JsonSerializable {
   public int hashCode() {
     return Objects
         .hash(environment, body, level, timestamp, codeVersion, platform, language, framework,
-            context, request, person, server, client, custom, fingerprint, title, uuid, notifier);
+            context, request, person, server, client, custom, fingerprint, title, uuid, isUncaught, notifier);
   }
 
   @Override
@@ -349,6 +362,7 @@ public class Data implements JsonSerializable {
         + ", fingerprint='" + fingerprint + '\''
         + ", title='" + title + '\''
         + ", uuid='" + uuid + '\''
+        + ", isUncaught='" + isUncaught + '\''
         + ", notifier=" + notifier
         + '}';
   }
@@ -392,6 +406,8 @@ public class Data implements JsonSerializable {
 
     private String uuid;
 
+    private boolean isUncaught;
+
     private Notifier notifier;
 
     /**
@@ -424,6 +440,7 @@ public class Data implements JsonSerializable {
       this.fingerprint = data.fingerprint;
       this.title = data.title;
       this.uuid = data.uuid;
+      this.isUncaught = data.isUncaught;
       this.notifier = data.notifier;
     }
 
@@ -629,6 +646,17 @@ public class Data implements JsonSerializable {
      */
     public Builder uuid(String uuid) {
       this.uuid = uuid;
+      return this;
+    }
+
+    /**
+     * Specify whether this data object originates from an uncaught exception or not.
+     *
+     * @param isUncaught true if this comes from an uncaught exception.
+     * @return the builder instance.
+     */
+    public Builder isUncaught(boolean isUncaught) {
+      this.isUncaught = isUncaught;
       return this;
     }
 

--- a/rollbar-java/src/main/java/com/rollbar/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/Rollbar.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 
 /**
- * This class is deprecated and provided as a convenience to ease the migration path
+ * This class is deprecated and provided as a convenience to ease the migration path.
  * from 0.5.4 to 1.0.0. For the simplest use cases, this class should provide the same
  * functionality as the old com.rollbar.Rollbar class by delegating to the new
  * com.rollbar.notifier.Rollbar class. For any new usage, do not use this class, prefer
@@ -29,7 +29,8 @@ public class Rollbar {
    * @param environment not nullable, the environment to send payloads under
    */
   public Rollbar(String accessToken, String environment) {
-    this(accessToken, environment, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    this(accessToken, environment, null, null, null, null, null, null, null, null,
+      null, null, null, null, null, null);
   }
 
   /**
@@ -39,33 +40,41 @@ public class Rollbar {
    * @param sender the sender to use. If null uses default: {@link Sender}
    */
   public Rollbar(String accessToken, String environment, Sender sender) {
-    this(accessToken, environment, sender, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    this(accessToken, environment, sender, null, null, null, null, null, null, null,
+      null, null, null, null, null, null);
   }
 
   /**
-   * Construct notifier with static values for all configuration options set. Anything left null will use the default
-   * value. If appropriate.
+   * Construct notifier with static values for all configuration options set. Anything left null
+   * will use the default value. If appropriate.
    * @param accessToken not nullable, the access token to send payloads to
    * @param environment not nullable, the environment to send payloads under
    * @param sender the sender to use. If null uses default: {@link Sender}
-   * @param codeVersion the version of the code currently running. If code checked out on server: `git rev-parse HEAD`
+   * @param codeVersion the version of the code currently running. If code checked out on
+   *        server: `git rev-parse HEAD`
    * @param platform the platform you're running. (JVM version, or similar).
-   * @param language the main language you're running ("java" by default, override w/ "clojure", "scala" etc.).
+   * @param language the main language you're running ("java" by default,
+   *        override w/ "clojure", "scala" etc.).
    * @param framework the framework you're using ("Play", "Spring", etc.).
    * @param context a mnemonic for finding the code responsible (e.g. controller name, module name)
-   * @param request the HTTP request that triggered this error. Can be set if the IOC container can work per-request.
+   * @param request the HTTP request that triggered this error. Can be set if the IOC container
+   *        can work per-request.
    * @param person the affected person. Can be set if the IOC container can work per-request.
    * @param server info about this server. This can be statically set.
    * @param custom custom info to send with *every* error. Can be dynamically or statically set.
-   * @param notifier information about this notifier. Default {@code new Notifier()} ({@link Notifier}.
-   * @param responseHandler what to do with the response. Use this to check for failures and handle some other way.
-   * @param filter filter used to determine if you will send payload. Receives *transformed* payload.
+   * @param notifier information about this notifier. Default {@code new Notifier()}
+   *        ({@link Notifier}.
+   * @param responseHandler what to do with the response. Use this to check for failures and handle
+   *        some other way.
+   * @param filter filter used to determine if you will send payload. Receives *transformed*
+   *        payload.
    * @param transform alter payload before sending.
    */
-  public Rollbar(String accessToken, String environment, Sender sender, String codeVersion, String platform,
-                 String language, String framework, final String context, final Request request, final Person person, final Server server,
-                 final Map<String, Object> custom, final Notifier notifier, SenderListener responseHandler,
-                 Filter filter, Transformer transform) {
+  public Rollbar(String accessToken, String environment, Sender sender, String codeVersion,
+                 String platform, String language, String framework, final String context,
+                 final Request request, final Person person, final Server server,
+                 final Map<String, Object> custom, final Notifier notifier,
+                 SenderListener responseHandler, Filter filter, Transformer transform) {
     sender = sender != null ? sender : new BufferedSender.Builder().build();
     if (responseHandler != null) {
       sender.addListener(responseHandler);
@@ -119,14 +128,14 @@ public class Rollbar {
   }
 
   /**
-   * Handle all uncaught errors on current thread with this `Rollbar`
+   * Handle all uncaught errors on current thread with this `Rollbar`.
    */
   public void handleUncaughtErrors() {
     handleUncaughtErrors(Thread.currentThread());
   }
 
   /**
-   * Handle all uncaught errors on {@code thread} with this `Rollbar`
+   * Handle all uncaught errors on {@code thread} with this `Rollbar`.
    * @param thread the thread to handle errors on
    */
   public void handleUncaughtErrors(Thread thread) {
@@ -139,7 +148,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a critical error
+   * Record a critical error.
    * @param error the error
    */
   public void critical(Throwable error) {
@@ -147,7 +156,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error
+   * Record an error.
    * @param error the error
    */
   public void error(Throwable error) {
@@ -155,7 +164,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error as a warning
+   * Record an error as a warning.
    * @param error the error
    */
   public void warning(Throwable error) {
@@ -163,7 +172,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error as an info
+   * Record an error as an info.
    * @param error the error
    */
   public void info(Throwable error) {
@@ -171,7 +180,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error as debugging information
+   * Record an error as debugging information.
    * @param error the error
    */
   public void debug(Throwable error) {
@@ -179,7 +188,7 @@ public class Rollbar {
   }
 
   /**
-   * Log an error at the default level
+   * Log an error at the default level.
    * @param error the error
    */
   public void log(Throwable error) {
@@ -196,7 +205,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a critical error with extra information attached
+   * Record a critical error with extra information attached.
    * @param error the error
    * @param custom the extra information
    */
@@ -205,7 +214,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with extra information attached
+   * Record an error with extra information attached.
    * @param error the error
    * @param custom the extra information
    */
@@ -214,7 +223,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a warning error with extra information attached
+   * Record a warning error with extra information attached.
    * @param error the error
    * @param custom the extra information
    */
@@ -223,7 +232,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an info error with extra information attached
+   * Record an info error with extra information attached.
    * @param error the error
    * @param custom the extra information
    */
@@ -232,7 +241,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debug error with extra information attached
+   * Record a debug error with extra information attached.
    * @param error the error
    * @param custom the extra information
    */
@@ -241,7 +250,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with extra information attached at the default level
+   * Record an error with extra information attached at the default level.
    * @param error the error
    * @param custom the extra information
    */
@@ -250,7 +259,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with extra information attached at the level specified
+   * Record an error with extra information attached at the level specified.
    * @param error the error
    * @param custom the extra information
    * @param level the level
@@ -260,7 +269,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a critical error with human readable description
+   * Record a critical error with human readable description.
    * @param error the error
    * @param description human readable description of error
    */
@@ -269,7 +278,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with human readable description
+   * Record an error with human readable description.
    * @param error the error
    * @param description human readable description of error
    */
@@ -278,7 +287,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a warning with human readable description
+   * Record a warning with human readable description.
    * @param error the error
    * @param description human readable description of error
    */
@@ -287,7 +296,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an info error with human readable description
+   * Record an info error with human readable description.
    * @param error the error
    * @param description human readable description of error
    */
@@ -296,7 +305,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debug error with human readable description
+   * Record a debug error with human readable description.
    * @param error the error
    * @param description human readable description of error
    */
@@ -305,7 +314,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with human readable description at the default level
+   * Record an error with human readable description at the default level.
    * @param error the error
    * @param description human readable description of error
    */
@@ -314,7 +323,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debug error with human readable description at the specified level
+   * Record a debug error with human readable description at the specified level.
    * @param error the error
    * @param description human readable description of error
    * @param level the level
@@ -324,7 +333,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a critical error with custom parameters and human readable description
+   * Record a critical error with custom parameters and human readable description.
    * @param error the error
    * @param custom the custom data
    * @param description the human readable description of error
@@ -334,7 +343,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with custom parameters and human readable description
+   * Record an error with custom parameters and human readable description.
    * @param error the error
    * @param custom the custom data
    * @param description the human readable description of error
@@ -344,7 +353,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a warning error with custom parameters and human readable description
+   * Record a warning error with custom parameters and human readable description.
    * @param error the error
    * @param custom the custom data
    * @param description the human readable description of error
@@ -354,7 +363,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an info error with custom parameters and human readable description
+   * Record an info error with custom parameters and human readable description.
    * @param error the error
    * @param custom the custom data
    * @param description the human readable description of error
@@ -364,7 +373,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debug error with custom parameters and human readable description
+   * Record a debug error with custom parameters and human readable description.
    * @param error the error
    * @param custom the custom data
    * @param description the human readable description of error
@@ -374,7 +383,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error with custom parameters and human readable description at the default level
+   * Record an error with custom parameters and human readable description at the default level.
    * @param error the error
    * @param custom the custom data
    * @param description the human readable description of error
@@ -384,7 +393,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a critical message
+   * Record a critical message.
    * @param message the message
    */
   public void critical(String message) {
@@ -392,7 +401,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an error message
+   * Record an error message.
    * @param message the message
    */
   public void error(String message) {
@@ -400,7 +409,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a warning message
+   * Record a warning message.
    * @param message the message
    */
   public void warning(String message) {
@@ -408,7 +417,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an informational message
+   * Record an informational message.
    * @param message the message
    */
   public void info(String message) {
@@ -416,7 +425,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debugging message
+   * Record a debugging message.
    * @param message the message
    */
   public void debug(String message) {
@@ -424,7 +433,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debugging message at the default level of WARNING
+   * Record a debugging message at the default level of WARNING.
    * @param message the message
    */
   public void log(String message) {
@@ -432,7 +441,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a message at the level specified
+   * Record a message at the level specified.
    * @param message the message
    * @param level the level
    */
@@ -441,7 +450,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a critical message with extra information attached
+   * Record a critical message with extra information attached.
    * @param message the message
    * @param custom the extra information
    */
@@ -450,7 +459,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a error message with extra information attached
+   * Record a error message with extra information attached.
    * @param message the message
    * @param custom the extra information
    */
@@ -459,7 +468,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a warning message with extra information attached
+   * Record a warning message with extra information attached.
    * @param message the message
    * @param custom the extra information
    */
@@ -468,7 +477,7 @@ public class Rollbar {
   }
 
   /**
-   * Record an informational message with extra information attached
+   * Record an informational message with extra information attached.
    * @param message the message
    * @param custom the extra information
    */
@@ -477,7 +486,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a debugging message with extra information attached
+   * Record a debugging message with extra information attached.
    * @param message the message
    * @param custom the extra information
    */
@@ -486,7 +495,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a message with extra information attached at the default level of WARNING
+   * Record a message with extra information attached at the default level of WARNING.
    * @param message the message
    * @param custom the extra information
    */
@@ -495,7 +504,7 @@ public class Rollbar {
   }
 
   /**
-   * Record a message with extra information attached at the specified level
+   * Record a message with extra information attached at the specified level.
    * @param message the message
    * @param custom the extra information
    * @param level the level
@@ -505,8 +514,10 @@ public class Rollbar {
   }
 
   /**
-   * Record an error or message with extra data at the level specified. At least ene of `error` or `description` must
-   * be non-null. If error is null, `description` will be sent as a message. If error is non-null, description will be
+   * Record an error or message with extra data at the level specified.
+   * At least ene of `error` or `description` must
+   * be non-null. If error is null, `description` will be sent as a message.
+   * If error is non-null, description will be
    * sent as the description of the error.
    * Custom data will be attached to message if the error is null.
    * @param error the error (if any)
@@ -519,8 +530,10 @@ public class Rollbar {
   }
 
   /**
-   * Record an error or message with extra data at the level specified. At least ene of `error` or `description` must
-   * be non-null. If error is null, `description` will be sent as a message. If error is non-null, description will be
+   * Record an error or message with extra data at the level specified.
+   * At least ene of `error` or `description` must
+   * be non-null. If error is null, `description` will be sent as a message.
+   * If error is non-null, description will be
    * sent as the description of the error.
    * Custom data will be attached to message if the error is null.
    * @param error the error (if any)
@@ -529,7 +542,8 @@ public class Rollbar {
    * @param level the level to send it at
    * @param isUncaught whether or not this set of data originates from an uncaught exception.
    */
-  public void log(Throwable error, Map<String, Object> custom, String description, Level level, boolean isUncaught) {
+  public void log(Throwable error, Map<String, Object> custom, String description, Level level,
+      boolean isUncaught) {
     this.rollbar.log(error, custom, description, level, isUncaught);
   }
 }

--- a/rollbar-java/src/main/java/com/rollbar/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/Rollbar.java
@@ -133,7 +133,7 @@ public class Rollbar {
     final Rollbar rollbar = this;
     thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
       public void uncaughtException(Thread t, Throwable e) {
-        rollbar.log(e);
+        rollbar.log(e, null, null, null, true);
       }
     });
   }
@@ -515,6 +515,21 @@ public class Rollbar {
    * @param level the level to send it at
    */
   public void log(Throwable error, Map<String, Object> custom, String description, Level level) {
-    this.rollbar.log(error, custom, description, level);
+    log(error, custom, description, level, false);
+  }
+
+  /**
+   * Record an error or message with extra data at the level specified. At least ene of `error` or `description` must
+   * be non-null. If error is null, `description` will be sent as a message. If error is non-null, description will be
+   * sent as the description of the error.
+   * Custom data will be attached to message if the error is null.
+   * @param error the error (if any)
+   * @param custom the custom data (if any)
+   * @param description the description of the error, or the message to send
+   * @param level the level to send it at
+   * @param isUncaught whether or not this set of data originates from an uncaught exception.
+   */
+  public void log(Throwable error, Map<String, Object> custom, String description, Level level, boolean isUncaught) {
+    this.rollbar.log(error, custom, description, level, isUncaught);
   }
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -573,7 +573,8 @@ public class Rollbar {
    * @param level the level to send it at.
    * @param isUncaught whether or not this data comes from an uncaught exception.
    */
-  public void log(Throwable error, Map<String, Object> custom, String description, Level level, boolean isUncaught) {
+  public void log(Throwable error, Map<String, Object> custom, String description, Level level,
+      boolean isUncaught) {
     try {
       process(error, custom, description, level, isUncaught);
     } catch (Exception e) {
@@ -656,8 +657,8 @@ public class Rollbar {
     sendPayload(config, payload);
   }
 
-  private Data buildData(Config config, Throwable error, Map<String, Object> custom, String description,
-      Level level, boolean isUncaught) {
+  private Data buildData(Config config, Throwable error, Map<String, Object> custom,
+      String description, Level level, boolean isUncaught) {
 
     Data.Builder dataBuilder = new Data.Builder()
         .environment(config.environment())

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -606,7 +606,7 @@ public class Rollbar {
     this.configReadLock.unlock();
 
     // Pre filter
-    if (config.filter() != null && config.filter().preProcess(level, error, custom, description, isUncaught)) {
+    if (config.filter() != null && config.filter().preProcess(level, error, custom, description)) {
       LOGGER.debug("Pre-filtered error: {}", error);
       return;
     }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigProvider.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigProvider.java
@@ -1,11 +1,11 @@
 package com.rollbar.notifier.config;
 
 public interface ConfigProvider {
-    /**
-     * Provides the config given a builder.
-     *
-     * @param builder an instance of {@link ConfigBuilder} with defaults set
-     * @return the config
-     */
-    Config provide(ConfigBuilder builder);
+  /**
+   * Provides the config given a builder.
+   *
+   * @param builder an instance of {@link ConfigBuilder} with defaults set
+   * @return the config
+   */
+  Config provide(ConfigBuilder builder);
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
@@ -17,11 +17,9 @@ public interface Filter {
    * @param error the error.
    * @param custom the custom data.
    * @param description the description.
-   * @param isUncaught whether or not this set of data originates from an uncaught exception.
    * @return true if filtered otherwise false.
    */
-  boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description,
-      boolean isUncaught);
+  boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description);
 
   /**
    * Post-filter hook to decide once the final payload is ready if it should be send to Rollbar.

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
@@ -17,30 +17,11 @@ public interface Filter {
    * @param error the error.
    * @param custom the custom data.
    * @param description the description.
-   * @return true if filtered otherwise false.
-   */
-  boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description);
-
-  /**
-   * Pre-filter hook to decide before gathering information and transforming the data if it is
-   * susceptible of it. This includes whether or not this data comes from an uncaught exception.
-   * By default this just calls preProcess method that ignores the isUncaught parameter.
-   * Only this method is called and therefore if you override the default implementation, the other
-   * preProcess method will never be called by this library. The existence of the two methods is for
-   * legacy reasons, but we encourage implementing this method as the less specific method may be
-   * dropped in a future release.
-   *
-   * @param level the level
-   * @param error the error.
-   * @param custom the custom data.
-   * @param description the description.
    * @param isUncaught whether or not this set of data originates from an uncaught exception.
    * @return true if filtered otherwise false.
    */
-  default boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description,
-      boolean isUncaught) {
-    return preProcess(level, error, custom, description);
-  }
+  boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description,
+      boolean isUncaught);
 
   /**
    * Post-filter hook to decide once the final payload is ready if it should be send to Rollbar.

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
@@ -11,7 +11,7 @@ public interface Filter {
 
   /**
    * Pre-filter hook to decide before gathering information and transforming the data if it is
-   * .susceptible of it.
+   * susceptible of it.
    *
    * @param level the level
    * @param error the error.
@@ -20,6 +20,27 @@ public interface Filter {
    * @return true if filtered otherwise false.
    */
   boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description);
+
+  /**
+   * Pre-filter hook to decide before gathering information and transforming the data if it is
+   * susceptible of it. This includes whether or not this data comes from an uncaught exception.
+   * By default this just calls preProcess method that ignores the isUncaught parameter.
+   * Only this method is called and therefore if you override the default implementation, the other
+   * preProcess method will never be called by this library. The existence of the two methods is for
+   * legacy reasons, but we encourage implementing this method as the less specific method may be
+   * dropped in a future release.
+   *
+   * @param level the level
+   * @param error the error.
+   * @param custom the custom data.
+   * @param description the description.
+   * @param isUncaught whether or not this set of data originates from an uncaught exception.
+   * @return true if filtered otherwise false.
+   */
+  default boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description,
+      boolean isUncaught) {
+    return preProcess(level, error, custom, description);
+  }
 
   /**
    * Post-filter hook to decide once the final payload is ready if it should be send to Rollbar.

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/FilterPipeline.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/FilterPipeline.java
@@ -28,9 +28,9 @@ public class FilterPipeline implements Filter {
 
   @Override
   public boolean preProcess(Level level, Throwable error, Map<String, Object> custom,
-      String description, boolean isUncaught) {
+      String description) {
     if (usePipeline()) {
-      return pipeline(level, error, custom, description, isUncaught);
+      return pipeline(level, error, custom, description);
     }
 
     return false;
@@ -50,9 +50,9 @@ public class FilterPipeline implements Filter {
   }
 
   private boolean pipeline(Level level, Throwable error, Map<String, Object> custom,
-      String description, boolean isUncaught) {
+      String description) {
     for (Filter filter : pipeline) {
-      boolean result = filter.preProcess(level, error, custom, description, isUncaught);
+      boolean result = filter.preProcess(level, error, custom, description);
       if (result) {
         return true;
       }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/FilterPipeline.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/FilterPipeline.java
@@ -28,16 +28,6 @@ public class FilterPipeline implements Filter {
 
   @Override
   public boolean preProcess(Level level, Throwable error, Map<String, Object> custom,
-      String description) {
-    if (usePipeline()) {
-      return pipeline(level, error, custom, description);
-    }
-
-    return false;
-  }
-
-  @Override
-  public boolean preProcess(Level level, Throwable error, Map<String, Object> custom,
       String description, boolean isUncaught) {
     if (usePipeline()) {
       return pipeline(level, error, custom, description, isUncaught);
@@ -57,17 +47,6 @@ public class FilterPipeline implements Filter {
 
   private boolean usePipeline() {
     return pipeline != null && !pipeline.isEmpty();
-  }
-
-  private boolean pipeline(Level level, Throwable error, Map<String, Object> custom,
-      String description) {
-    for (Filter filter : pipeline) {
-      boolean result = filter.preProcess(level, error, custom, description);
-      if (result) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private boolean pipeline(Level level, Throwable error, Map<String, Object> custom,

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/FilterPipeline.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/FilterPipeline.java
@@ -37,6 +37,16 @@ public class FilterPipeline implements Filter {
   }
 
   @Override
+  public boolean preProcess(Level level, Throwable error, Map<String, Object> custom,
+      String description, boolean isUncaught) {
+    if (usePipeline()) {
+      return pipeline(level, error, custom, description, isUncaught);
+    }
+
+    return false;
+  }
+
+  @Override
   public boolean postProcess(Data data) {
     if (usePipeline()) {
       return pipeline(data);
@@ -53,6 +63,17 @@ public class FilterPipeline implements Filter {
       String description) {
     for (Filter filter : pipeline) {
       boolean result = filter.preProcess(level, error, custom, description);
+      if (result) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean pipeline(Level level, Throwable error, Map<String, Object> custom,
+      String description, boolean isUncaught) {
+    for (Filter filter : pipeline) {
+      boolean result = filter.preProcess(level, error, custom, description, isUncaught);
       if (result) {
         return true;
       }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/AbstractSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/AbstractSender.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractSender implements Sender {
 
-  private Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+  private Logger thisLogger = LoggerFactory.getLogger(this.getClass());
 
   private final List<SenderListener> listeners = new ArrayList<>();
 
@@ -61,14 +61,14 @@ public abstract class AbstractSender implements Sender {
   }
 
   private void notifyResult(Payload payload, Response response) {
-    LOGGER.debug("Payload sent uuid: {}", response.getResult().getContent());
+    thisLogger.debug("Payload sent uuid: {}", response.getResult().getContent());
     for (SenderListener listener : listeners) {
       listener.onResponse(payload, response);
     }
   }
 
   private void notifyError(Payload payload, Exception error) {
-    LOGGER.error("Error sending the payload.", error);
+    thisLogger.error("Error sending the payload.", error);
     for (SenderListener listener : listeners) {
       listener.onError(payload, error);
     }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandler.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandler.java
@@ -26,7 +26,7 @@ public class RollbarUncaughtExceptionHandler implements Thread.UncaughtException
 
   @Override
   public void uncaughtException(Thread thread, Throwable throwable) {
-    rollbar.log(throwable);
+    rollbar.log(throwable, null, null, null, true);
 
     if (delegate != null) {
       delegate.uncaughtException(thread, throwable);

--- a/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
@@ -21,25 +21,25 @@ public class BodyFactory {
   public Body from(Throwable throwable, String description) {
     Body.Builder builder = new Body.Builder();
     if (throwable == null) {
-        return builder.bodyContent(message(description)).build();
+      return builder.bodyContent(message(description)).build();
     }
     if (throwable.getCause() == null) {
-        return builder.bodyContent(trace(throwable, description)).build();
+      return builder.bodyContent(trace(throwable, description)).build();
     }
     return builder.bodyContent(traceChain(throwable, description)).build();
   }
 
   private static Message message(String description) {
-      return new Message.Builder()
-              .body(description)
-              .build();
+    return new Message.Builder()
+      .body(description)
+      .build();
   }
 
   private static Trace trace(Throwable throwable, String description) {
     return new Trace.Builder()
-        .frames(frames(throwable))
-        .exception(info(throwable, description))
-        .build();
+      .frames(frames(throwable))
+      .exception(info(throwable, description))
+      .build();
   }
 
   private static TraceChain traceChain(Throwable throwable, String description) {

--- a/rollbar-java/src/test/java/com/rollbar/notifier/filter/FilterPipelineTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/filter/FilterPipelineTest.java
@@ -29,21 +29,22 @@ public class FilterPipelineTest {
     Filter filter1 = mock(Filter.class);
     Filter filter2 = mock(Filter.class);
 
-    when(filter1.preProcess(any(), any(), any(), any())).thenReturn(false);
-    when(filter2.preProcess(any(), any(), any(), any())).thenReturn(true);
+    when(filter1.preProcess(any(), any(), any(), any(), any())).thenReturn(false);
+    when(filter2.preProcess(any(), any(), any(), any(), any())).thenReturn(true);
 
     Level level = Level.ERROR;
     Throwable error = new RuntimeException("Something went wrong.");
     Map<String, Object> custom = emptyMap();
     String description = "Error description";
+    boolean isUncaught = true;
 
     FilterPipeline sut = new FilterPipeline(asList(filter1, filter2));
 
-    boolean result = sut.preProcess(level, error, custom, description);
+    boolean result = sut.preProcess(level, error, custom, description, isUncaught);
 
     assertThat(result, is(true));
-    verify(filter1).preProcess(level, error, custom, description);
-    verify(filter2).preProcess(level, error, custom, description);
+    verify(filter1).preProcess(level, error, custom, description, isUncaught);
+    verify(filter2).preProcess(level, error, custom, description, isUncaught);
   }
 
   @Test
@@ -51,21 +52,22 @@ public class FilterPipelineTest {
     Filter filter1 = mock(Filter.class);
     Filter filter2 = mock(Filter.class);
 
-    when(filter1.preProcess(any(), any(), any(), any())).thenReturn(true);
-    when(filter2.preProcess(any(), any(), any(), any())).thenReturn(false);
+    when(filter1.preProcess(any(), any(), any(), any(), any())).thenReturn(true);
+    when(filter2.preProcess(any(), any(), any(), any(), any())).thenReturn(false);
 
     Level level = Level.ERROR;
     Throwable error = new RuntimeException("Something went wrong.");
     Map<String, Object> custom = emptyMap();
     String description = "Error description";
+    boolean isUncaught = true;
 
     FilterPipeline sut = new FilterPipeline(asList(filter1, filter2));
 
-    boolean result = sut.preProcess(level, error, custom, description);
+    boolean result = sut.preProcess(level, error, custom, description, isUncaught);
 
     assertThat(result, is(true));
-    verify(filter1).preProcess(level, error, custom, description);
-    verify(filter2, never()).preProcess(level, error, custom, description);
+    verify(filter1).preProcess(level, error, custom, description, isUncaught);
+    verify(filter2, never()).preProcess(level, error, custom, description, isUncaught);
   }
 
   @Test
@@ -113,7 +115,7 @@ public class FilterPipelineTest {
     Data data = mock(Data.class);
 
     boolean resultPreProcess = sut.preProcess(Level.ERROR, new RuntimeException(),
-        emptyMap(), "");
+        emptyMap(), "", true);
     boolean resultPostProcess = sut.postProcess(data);
 
     assertThat(resultPreProcess, is(false));
@@ -127,7 +129,7 @@ public class FilterPipelineTest {
     Data data = mock(Data.class);
 
     boolean resultPreProcess = sut.preProcess(Level.ERROR, new RuntimeException(),
-        emptyMap(), "");
+        emptyMap(), "", true);
     boolean resultPostProcess = sut.postProcess(data);
 
     assertThat(resultPreProcess, is(false));

--- a/rollbar-java/src/test/java/com/rollbar/notifier/filter/FilterPipelineTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/filter/FilterPipelineTest.java
@@ -29,22 +29,21 @@ public class FilterPipelineTest {
     Filter filter1 = mock(Filter.class);
     Filter filter2 = mock(Filter.class);
 
-    when(filter1.preProcess(any(), any(), any(), any(), any())).thenReturn(false);
-    when(filter2.preProcess(any(), any(), any(), any(), any())).thenReturn(true);
+    when(filter1.preProcess(any(), any(), any(), any())).thenReturn(false);
+    when(filter2.preProcess(any(), any(), any(), any())).thenReturn(true);
 
     Level level = Level.ERROR;
     Throwable error = new RuntimeException("Something went wrong.");
     Map<String, Object> custom = emptyMap();
     String description = "Error description";
-    boolean isUncaught = true;
 
     FilterPipeline sut = new FilterPipeline(asList(filter1, filter2));
 
-    boolean result = sut.preProcess(level, error, custom, description, isUncaught);
+    boolean result = sut.preProcess(level, error, custom, description);
 
     assertThat(result, is(true));
-    verify(filter1).preProcess(level, error, custom, description, isUncaught);
-    verify(filter2).preProcess(level, error, custom, description, isUncaught);
+    verify(filter1).preProcess(level, error, custom, description);
+    verify(filter2).preProcess(level, error, custom, description);
   }
 
   @Test
@@ -52,22 +51,21 @@ public class FilterPipelineTest {
     Filter filter1 = mock(Filter.class);
     Filter filter2 = mock(Filter.class);
 
-    when(filter1.preProcess(any(), any(), any(), any(), any())).thenReturn(true);
-    when(filter2.preProcess(any(), any(), any(), any(), any())).thenReturn(false);
+    when(filter1.preProcess(any(), any(), any(), any())).thenReturn(true);
+    when(filter2.preProcess(any(), any(), any(), any())).thenReturn(false);
 
     Level level = Level.ERROR;
     Throwable error = new RuntimeException("Something went wrong.");
     Map<String, Object> custom = emptyMap();
     String description = "Error description";
-    boolean isUncaught = true;
 
     FilterPipeline sut = new FilterPipeline(asList(filter1, filter2));
 
-    boolean result = sut.preProcess(level, error, custom, description, isUncaught);
+    boolean result = sut.preProcess(level, error, custom, description);
 
     assertThat(result, is(true));
-    verify(filter1).preProcess(level, error, custom, description, isUncaught);
-    verify(filter2, never()).preProcess(level, error, custom, description, isUncaught);
+    verify(filter1).preProcess(level, error, custom, description);
+    verify(filter2, never()).preProcess(level, error, custom, description);
   }
 
   @Test
@@ -115,7 +113,7 @@ public class FilterPipelineTest {
     Data data = mock(Data.class);
 
     boolean resultPreProcess = sut.preProcess(Level.ERROR, new RuntimeException(),
-        emptyMap(), "", true);
+        emptyMap(), "");
     boolean resultPostProcess = sut.postProcess(data);
 
     assertThat(resultPreProcess, is(false));
@@ -129,7 +127,7 @@ public class FilterPipelineTest {
     Data data = mock(Data.class);
 
     boolean resultPreProcess = sut.preProcess(Level.ERROR, new RuntimeException(),
-        emptyMap(), "", true);
+        emptyMap(), "");
     boolean resultPostProcess = sut.postProcess(data);
 
     assertThat(resultPreProcess, is(false));

--- a/rollbar-java/src/test/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandlerTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandlerTest.java
@@ -34,7 +34,7 @@ public class RollbarUncaughtExceptionHandlerTest {
 
     sut.uncaughtException(thread, throwable);
 
-    verify(rollbar).log(throwable);
+    verify(rollbar).log(throwable, null, null, null, true);
     verify(uncaughtExceptionHandler, never()).uncaughtException(thread, throwable);
   }
 
@@ -45,7 +45,7 @@ public class RollbarUncaughtExceptionHandlerTest {
 
     sut.uncaughtException(thread, throwable);
 
-    verify(rollbar).log(throwable);
+    verify(rollbar).log(throwable, null, null, null, true);
     verify(uncaughtExceptionHandler).uncaughtException(thread, throwable);
   }
 


### PR DESCRIPTION
There are certain use cases where people want to know if a set of data
comes from an uncaught exception or not. Add this information to the
data object and to the filter interface. This way we can use our
existing filter and transform infrastructure for dealing with this data.

Fixes #93