### PR TITLE
Allow arbitrary extra data in API objects that support this loose format

### DIFF
--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Client.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Client.java
@@ -15,8 +15,8 @@ public class Client implements JsonSerializable {
   private final Map<String, Object> topLevelData;
 
   private Client(Builder builder) {
-    this.data = unmodifiableMap(builder.data);
-    this.topLevelData = unmodifiableMap(builder.topLevelData);
+    this.data = unmodifiableMap(new HashMap<>(builder.data));
+    this.topLevelData = unmodifiableMap(new HashMap<>(builder.topLevelData));
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Person.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Person.java
@@ -22,7 +22,7 @@ public class Person implements JsonSerializable {
     this.id = builder.id;
     this.username = builder.username;
     this.email = builder.email;
-    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
+    this.metadata = builder.metadata != null ? unmodifiableMap(new HashMap<>(builder.metadata)) : null;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Person.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Person.java
@@ -1,5 +1,6 @@
 package com.rollbar.api.payload.data;
 
+import static java.util.Collections.unmodifiableMap;
 import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,10 +16,13 @@ public class Person implements JsonSerializable {
 
   private final String email;
 
+  private final Map<String, Object> metadata;
+
   private Person(Builder builder) {
     this.id = builder.id;
     this.username = builder.username;
     this.email = builder.email;
+    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
   }
 
   /**
@@ -45,10 +49,21 @@ public class Person implements JsonSerializable {
     return this.email;
   }
 
+  /**
+   * Getter.
+   * @return the metadata.
+   */
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
   @Override
   public Map<String, Object> asJson() {
     Map<String, Object> values = new HashMap<>();
 
+    if (metadata != null) {
+      values.putAll(metadata);
+    }
     if (id != null) {
       values.put("id", id);
     }
@@ -79,6 +94,9 @@ public class Person implements JsonSerializable {
     if (username != null ? !username.equals(person.username) : person.username != null) {
       return false;
     }
+    if (metadata != null ? !metadata.equals(person.metadata) : person.metadata != null) {
+      return false;
+    }
     return email != null ? email.equals(person.email) : person.email == null;
   }
 
@@ -87,6 +105,7 @@ public class Person implements JsonSerializable {
     int result = id != null ? id.hashCode() : 0;
     result = 31 * result + (username != null ? username.hashCode() : 0);
     result = 31 * result + (email != null ? email.hashCode() : 0);
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
     return result;
   }
 
@@ -96,6 +115,7 @@ public class Person implements JsonSerializable {
         + "id='" + id + '\''
         + ", username='" + username + '\''
         + ", email='" + email + '\''
+        + ", metadata='" + metadata + '\''
         + '}';
   }
 
@@ -109,6 +129,8 @@ public class Person implements JsonSerializable {
     private String username;
 
     private String email;
+
+    private Map<String, Object> metadata;
 
     /**
      * Constructor.
@@ -126,6 +148,7 @@ public class Person implements JsonSerializable {
       this.id = person.id;
       this.username = person.username;
       this.email = person.email;
+      this.metadata = person.metadata;
     }
 
     /**
@@ -158,6 +181,17 @@ public class Person implements JsonSerializable {
      */
     public Builder email(String email) {
       this.email = email;
+      return this;
+    }
+
+    /**
+     * Extra metadata to include with the person.
+     *
+     * @param metadata the additional metadata.
+     * @return the builder instance.
+     */
+    public Builder metadata(Map<String, Object> metadata) {
+      this.metadata = metadata;
       return this;
     }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
@@ -1,5 +1,6 @@
 package com.rollbar.api.payload.data;
 
+import static java.util.Collections.unmodifiableMap;
 import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,8 @@ public class Request implements JsonSerializable {
 
   private final String userIp;
 
+  private final Map<String, Object> metadata;
+
   private Request(Builder builder) {
     this.url = builder.url;
     this.method = builder.method;
@@ -38,6 +41,7 @@ public class Request implements JsonSerializable {
     this.post = builder.post;
     this.body = builder.body;
     this.userIp = builder.userIp;
+    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
   }
 
   /**
@@ -112,10 +116,21 @@ public class Request implements JsonSerializable {
     return userIp;
   }
 
+  /**
+   * Getter.
+   * @return the metadata.
+   */
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
   @Override
   public Map<String, Object> asJson() {
     Map<String, Object> values = new HashMap<>();
 
+    if (metadata != null) {
+      values.putAll(metadata);
+    }
     if (url != null) {
       values.put("url", url);
     }
@@ -194,6 +209,9 @@ public class Request implements JsonSerializable {
     if (body != null ? !body.equals(request.body) : request.body != null) {
       return false;
     }
+    if (metadata != null ? !metadata.equals(request.metadata) : request.metadata != null) {
+      return false;
+    }
     return userIp != null ? userIp.equals(request.userIp) : request.userIp == null;
   }
 
@@ -208,6 +226,7 @@ public class Request implements JsonSerializable {
     result = 31 * result + (post != null ? post.hashCode() : 0);
     result = 31 * result + (body != null ? body.hashCode() : 0);
     result = 31 * result + (userIp != null ? userIp.hashCode() : 0);
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
     return result;
   }
 
@@ -223,6 +242,7 @@ public class Request implements JsonSerializable {
         + ", post=" + post
         + ", body='" + body + '\''
         + ", userIp='" + userIp + '\''
+        + ", metadata='" + metadata + '\''
         + '}';
   }
 
@@ -249,6 +269,8 @@ public class Request implements JsonSerializable {
 
     private String userIp;
 
+    private Map<String, Object> metadata;
+
     /**
      * Constructor.
      */
@@ -271,6 +293,7 @@ public class Request implements JsonSerializable {
       this.post = request.post;
       this.body = request.body;
       this.userIp = request.userIp;
+      this.metadata = request.metadata;
     }
 
     /**
@@ -369,6 +392,17 @@ public class Request implements JsonSerializable {
      */
     public Builder userIp(String userIp) {
       this.userIp = userIp;
+      return this;
+    }
+
+    /**
+     * Extra metadata to include with the request.
+     *
+     * @param metadata the additional metadata.
+     * @return the builder instance.
+     */
+    public Builder metadata(Map<String, Object> metadata) {
+      this.metadata = metadata;
       return this;
     }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
@@ -41,7 +41,7 @@ public class Request implements JsonSerializable {
     this.post = builder.post;
     this.body = builder.body;
     this.userIp = builder.userIp;
-    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
+    this.metadata = builder.metadata != null ? unmodifiableMap(new HashMap<>(builder.metadata)) : null;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Server.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Server.java
@@ -25,7 +25,7 @@ public class Server implements JsonSerializable {
     this.root = builder.root;
     this.branch = builder.branch;
     this.codeVersion = builder.codeVersion;
-    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
+    this.metadata = builder.metadata != null ? unmodifiableMap(new HashMap<>(builder.metadata)) : null;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Server.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Server.java
@@ -1,5 +1,6 @@
 package com.rollbar.api.payload.data;
 
+import static java.util.Collections.unmodifiableMap;
 import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,11 +18,14 @@ public class Server implements JsonSerializable {
 
   private final String codeVersion;
 
+  private final Map<String, Object> metadata;
+
   private Server(Builder builder) {
     this.host = builder.host;
     this.root = builder.root;
     this.branch = builder.branch;
     this.codeVersion = builder.codeVersion;
+    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
   }
 
   /**
@@ -56,10 +60,21 @@ public class Server implements JsonSerializable {
     return codeVersion;
   }
 
+  /**
+   * Getter.
+   * @return the metadata.
+   */
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
   @Override
   public Map<String, Object> asJson() {
     Map<String, Object> values = new HashMap<>();
 
+    if (metadata != null) {
+      values.putAll(metadata);
+    }
     if (host != null) {
       values.put("host", host);
     }
@@ -96,6 +111,9 @@ public class Server implements JsonSerializable {
     if (branch != null ? !branch.equals(server.branch) : server.branch != null) {
       return false;
     }
+    if (metadata != null ? !metadata.equals(server.metadata) : server.metadata != null) {
+      return false;
+    }
     return codeVersion != null ? codeVersion.equals(server.codeVersion)
         : server.codeVersion == null;
   }
@@ -106,6 +124,7 @@ public class Server implements JsonSerializable {
     result = 31 * result + (root != null ? root.hashCode() : 0);
     result = 31 * result + (branch != null ? branch.hashCode() : 0);
     result = 31 * result + (codeVersion != null ? codeVersion.hashCode() : 0);
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
     return result;
   }
 
@@ -116,6 +135,7 @@ public class Server implements JsonSerializable {
         + ", root='" + root + '\''
         + ", branch='" + branch + '\''
         + ", codeVersion='" + codeVersion + '\''
+        + ", metadata='" + metadata + '\''
         + '}';
   }
 
@@ -131,6 +151,8 @@ public class Server implements JsonSerializable {
     private String branch;
 
     private String codeVersion;
+
+    private Map<String, Object> metadata;
 
     /**
      * Constructor.
@@ -149,6 +171,7 @@ public class Server implements JsonSerializable {
       this.root = server.root;
       this.branch = server.branch;
       this.codeVersion = server.codeVersion;
+      this.metadata = server.metadata;
     }
 
     /**
@@ -195,6 +218,16 @@ public class Server implements JsonSerializable {
       return this;
     }
 
+    /**
+     * Extra metadata to include with the server.
+     *
+     * @param metadata the additional metadata.
+     * @return the builder instance.
+     */
+    public Builder metadata(Map<String, Object> metadata) {
+      this.metadata = metadata;
+      return this;
+    }
 
     /**
      * Builds the {@link Server server}.

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/CodeContext.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/CodeContext.java
@@ -4,6 +4,7 @@ import static java.util.Collections.unmodifiableList;
 
 import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -18,8 +19,8 @@ public class CodeContext implements JsonSerializable {
   private final List<String> post;
 
   private CodeContext(Builder builder) {
-    this.pre = builder.pre != null ? unmodifiableList(builder.pre) : null;
-    this.post = builder.post != null ? unmodifiableList(builder.post) : null;
+    this.pre = builder.pre != null ? unmodifiableList(new ArrayList<>(builder.pre)) : null;
+    this.post = builder.post != null ? unmodifiableList(new ArrayList<>(builder.post)) : null;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Frame.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Frame.java
@@ -5,6 +5,7 @@ import static java.util.Collections.unmodifiableMap;
 
 import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -39,8 +40,8 @@ public class Frame implements JsonSerializable {
     this.code = builder.code;
     this.className = builder.className;
     this.context = builder.context;
-    this.args = builder.args != null ? unmodifiableList(builder.args) : null;
-    this.keywordArgs = builder.keywordArgs != null ? unmodifiableMap(builder.keywordArgs) : null;
+    this.args = builder.args != null ? unmodifiableList(new ArrayList<>(builder.args)) : null;
+    this.keywordArgs = builder.keywordArgs != null ? unmodifiableMap(new HashMap<>(builder.keywordArgs)) : null;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Message.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Message.java
@@ -17,7 +17,7 @@ public class Message implements BodyContent, JsonSerializable {
 
   private Message(Builder builder) {
     this.body = builder.body;
-    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
+    this.metadata = builder.metadata != null ? unmodifiableMap(new HashMap<>(builder.metadata)) : null;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Message.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Message.java
@@ -1,7 +1,8 @@
 package com.rollbar.api.payload.data.body;
 
-import com.rollbar.api.json.JsonSerializable;
+import static java.util.Collections.unmodifiableMap;
 
+import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -12,9 +13,11 @@ import java.util.Objects;
 public class Message implements BodyContent, JsonSerializable {
 
   private final String body;
+  private final Map<String, Object> metadata;
 
   private Message(Builder builder) {
     this.body = builder.body;
+    this.metadata = builder.metadata != null ? unmodifiableMap(builder.metadata) : null;
   }
 
   /**
@@ -25,6 +28,14 @@ public class Message implements BodyContent, JsonSerializable {
     return body;
   }
 
+  /**
+   * Getter.
+   * @return the metadata.
+   */
+  public Map<String, Object> getMetadata() {
+    return metadata;
+  }
+
   @Override
   public String getKeyName() {
     return "message";
@@ -32,7 +43,10 @@ public class Message implements BodyContent, JsonSerializable {
 
   @Override
   public Object asJson() {
-    Map<String, String> message = new HashMap<>();
+    Map<String, Object> message = new HashMap<>();
+    if (this.metadata != null) {
+      message.putAll(this.metadata);
+    }
     message.put("body", this.body);
     return message;
   }
@@ -46,18 +60,24 @@ public class Message implements BodyContent, JsonSerializable {
       return false;
     }
     Message message = (Message) o;
-    return Objects.equals(body, message.body);
+    if (body != null ? !Objects.equals(body, message.body) : message.body != null) {
+      return false;
+    }
+    return metadata != null ? metadata.equals(message.metadata) : message.metadata == null;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(body);
+    int result = body != null ? Objects.hash(body) : 0;
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+    return result;
   }
 
   @Override
   public String toString() {
     return "Message{"
         + "body='" + body + '\''
+        + ", metadata='" + metadata + '\''
         + '}';
   }
 
@@ -67,6 +87,7 @@ public class Message implements BodyContent, JsonSerializable {
   public static final class Builder {
 
     private String body;
+    private Map<String, Object> metadata;
 
     /**
      * Constructor.
@@ -92,6 +113,17 @@ public class Message implements BodyContent, JsonSerializable {
      */
     public Builder body(String body) {
       this.body = body;
+      return this;
+    }
+
+    /**
+     * Extra metadata to include with the message.
+     *
+     * @param metadata the additional metadata.
+     * @return the builder instance.
+     */
+    public Builder metadata(Map<String, Object> metadata) {
+      this.metadata = metadata;
       return this;
     }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Trace.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Trace.java
@@ -4,6 +4,7 @@ import static java.util.Collections.unmodifiableList;
 
 import com.rollbar.api.json.JsonSerializable;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -17,7 +18,7 @@ public class Trace implements BodyContent, JsonSerializable {
   private final ExceptionInfo exception;
 
   private Trace(Builder builder) {
-    this.frames = unmodifiableList(builder.frames);
+    this.frames = unmodifiableList(new ArrayList<>(builder.frames));
     this.exception = builder.exception;
   }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/TraceChain.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/TraceChain.java
@@ -3,6 +3,7 @@ package com.rollbar.api.payload.data.body;
 import static java.util.Collections.unmodifiableList;
 
 import com.rollbar.api.json.JsonSerializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -14,7 +15,7 @@ public class TraceChain implements BodyContent, JsonSerializable {
   private final List<Trace> traces;
 
   public TraceChain(Builder builder) {
-    this.traces = builder.traces != null ? unmodifiableList(builder.traces) : null;
+    this.traces = builder.traces != null ? unmodifiableList(new ArrayList<>(builder.traces)) : null;
   }
 
   /**

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/PersonTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/PersonTest.java
@@ -35,4 +35,33 @@ public class PersonTest {
 
     assertThat(person.asJson(), is(expected));
   }
+
+  @Test
+  public void shouldAllowMetadata() {
+    Person basePerson = person();
+
+    Map<String, Object> metadataMap = new HashMap<>();
+    metadataMap.put("a", "b");
+    metadataMap.put("num", 42);
+    metadataMap.put("id", "should not show up");
+
+    Person person = new Person.Builder(basePerson)
+      .metadata(metadataMap)
+      .build();
+
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("a", "b");
+    expected.put("num", 42);
+    if (person.getId() != null) {
+      expected.put("id", person.getId());
+    }
+    if (person.getEmail() != null) {
+      expected.put("email", person.getEmail());
+    }
+    if (person.getUsername() != null) {
+      expected.put("username", person.getUsername());
+    }
+
+    assertThat(person.asJson(), is(expected));
+  }
 }

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/RequestTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/RequestTest.java
@@ -61,4 +61,56 @@ public class RequestTest {
 
     assertThat(request.asJson(), is(expected));
   }
+
+  @Test
+  public void shouldAllowMetadata() {
+    Map<String, List<String>> get = new HashMap<>();
+    get.put("param1", asList("value1.1", "value1.2"));
+    get.put("param2", asList("value2.1"));
+    Map<String, Object> expectedGet = new HashMap<>();
+    expectedGet.put("param1", get.get("param1"));
+    expectedGet.put("param2", "value2.1");
+
+    Request baseRequest = request(get);
+
+    Map<String, Object> metadataMap = new HashMap<>();
+    metadataMap.put("a", "b");
+    metadataMap.put("num", 42);
+    metadataMap.put("url", "should not show up");
+
+    Request request = new Request.Builder(baseRequest)
+      .metadata(metadataMap)
+      .build();
+
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("a", "b");
+    expected.put("num", 42);
+
+    if (request.getUrl() != null) {
+      expected.put("url", request.getUrl());
+    }
+    if (request.getHeaders() != null) {
+      expected.put("headers", request.getHeaders());
+    }
+    if (request.getParams() != null) {
+      expected.put("params", request.getParams());
+    }
+    if (request.getGet() != null) {
+      expected.put("get", expectedGet);
+    }
+    if (request.getQueryString() != null) {
+      expected.put("query_string", request.getQueryString());
+    }
+    if (request.getPost() != null) {
+      expected.put("post", request.getPost());
+    }
+    if (request.getBody() != null) {
+      expected.put("body", request.getBody());
+    }
+    if (request.getUserIp() != null) {
+      expected.put("user_ip", request.getUserIp());
+    }
+
+    assertThat(request.asJson(), is(expected));
+  }
 }

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/ServerTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/ServerTest.java
@@ -39,4 +39,36 @@ public class ServerTest {
 
     assertThat(server.asJson(), is(expected));
   }
+
+  @Test
+  public void shouldAllowMetadata() {
+    Server baseServer = server();
+    Map<String, Object> metadataMap = new HashMap<>();
+    metadataMap.put("a", "b");
+    metadataMap.put("num", 42);
+    metadataMap.put("host", "should not show up");
+
+    Server server = new Server.Builder(baseServer)
+      .metadata(metadataMap)
+      .build();
+
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("a", "b");
+    expected.put("num", 42);
+
+    if (server.getHost() != null) {
+      expected.put("host", server.getHost());
+    }
+    if (server.getRoot() != null) {
+      expected.put("root", server.getRoot());
+    }
+    if (server.getBranch() != null) {
+      expected.put("branch", server.getBranch());
+    }
+    if (server.getCodeVersion() != null) {
+      expected.put("code_version", server.getCodeVersion());
+    }
+
+    assertThat(server.asJson(), is(expected));
+  }
 }

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/body/MessageTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/body/MessageTest.java
@@ -29,4 +29,23 @@ public class MessageTest {
     assertThat(message.getKeyName(), is("message"));
     assertThat(message.asJson(), is(expected));
   }
+
+  @Test
+  public void shouldAllowMetadata() {
+    Map<String, Object> metadataMap = new HashMap<>();
+    metadataMap.put("a", "b");
+    metadataMap.put("num", 42);
+    metadataMap.put("body", "should not show up");
+    Message message = new Message.Builder()
+      .body("hello world")
+      .metadata(metadataMap)
+      .build();
+
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("a", "b");
+    expected.put("num", 42);
+    expected.put("body", "hello world");
+
+    assertThat(message.asJson(), is(expected));
+  }
 }

--- a/rollbar-api/src/test/java/com/rollbar/test/Factory.java
+++ b/rollbar-api/src/test/java/com/rollbar/test/Factory.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 public class Factory {
 
+  private static final long CURRENT_TIME = System.currentTimeMillis();
+
   private Factory() {
 
   }
@@ -174,7 +176,7 @@ public class Factory {
         .level(Level.ERROR)
         .codeVersion("1.2.3")
         .platform("linux")
-        .timestamp(System.currentTimeMillis())
+        .timestamp(CURRENT_TIME)
         .language("java")
         .framework("spring")
         .request(request())


### PR DESCRIPTION
In the [API docs](https://rollbar.com/docs/api/items_post/) some of the elements in the payload body support arbitrary extra data with a comment that starts like `// Can contain any arbitrary keys.`. This PR adds back the ability to include this extra data with the various objects that the API understands, namely: `Server`, `Message`, `Request`. `Client` already supports this. Additionally, the docs don't mention it but we have always supported arbitrary extra data with `Person` so this adds that capacity as well.

The general form is to use the Builder for each type and to pass in a `Map<String, Object>` to the `metadata` function. This map will get merged into the final JSON for that object before the standard keys are added. That means that keys that are standard such as `body` for the `Message` type will be overwritten if they exist in this metadata object. See the tests added herein for examples of this behaviour.

Fixes #86 