### PR TITLE
Log4j2 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There are currently four libraries in this repository:
 * `rollbar-java`
 * `rollbar-web`
 * `rollbar-android`
+* `rollbar-log4j2`
 
 `rollbar-api` is a set of data objects representing structures that make up the payload
 the backend API understands.
@@ -193,6 +194,7 @@ For actual usage, the easiest way to get started is by looking at the examples:
 - [rollbar-web](https://github.com/rollbar/rollbar-java/tree/master/examples/rollbar-web)
 - [rollbar-android](https://github.com/rollbar/rollbar-java/tree/master/examples/rollbar-android)
 - [rollbar-scala](https://github.com/rollbar/rollbar-java/tree/master/examples/rollbar-scala)
+- [rollbar-log4j2](https://github.com/rollbar/rollbar-java/tree/master/examples/rollbar-log4j2)
 
 
 ### Spring 

--- a/examples/rollbar-log4j2/build.gradle
+++ b/examples/rollbar-log4j2/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'application'
+
+jar {
+    baseName = "rollbar-log4j2-example"
+    version =  '1.0.0'
+}
+
+mainClassName = "com.rollbar.log4j2.example.Application"
+
+dependencies {
+    compile project(":rollbar-log4j2")
+
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.0'
+}

--- a/examples/rollbar-log4j2/src/main/java/com/rollbar/log4j2/example/Application.java
+++ b/examples/rollbar-log4j2/src/main/java/com/rollbar/log4j2/example/Application.java
@@ -1,0 +1,75 @@
+package com.rollbar.log4j2.example;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+/**
+ * Application example using rollbar-log4j2 notifier.
+ */
+public class Application {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger("com.example.rollbar.log4j2");
+
+  public static void main(String[] args) {
+    LOGGER.info("Starting the application! Current time: {}", System.currentTimeMillis());
+
+    MDC.put("my_custom_key", "custom_value");
+
+    execute();
+
+    LOGGER.info("Finishing the application! Current time: {}", System.currentTimeMillis());
+  }
+
+  private static void execute() {
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    List<Callable<Void>> callableTasks = new ArrayList<>();
+
+    Greeting greeting = new Greeting();
+
+    for (int i = 0; i < 20; i++) {
+      callableTasks.add(new GreetingTask(i + 1, greeting));
+    }
+
+    try {
+      executor.invokeAll(callableTasks);
+    } catch (InterruptedException e) {
+      LOGGER.error("Unexpectedly the execution was interrupted.", e);
+    } finally {
+      executor.shutdown();
+    }
+  }
+
+  private static final class GreetingTask implements Callable<Void> {
+
+    private final int taskNumber;
+
+    private final Greeting greeting;
+
+    public GreetingTask(int taskNumber, Greeting greeting) {
+      this.taskNumber = taskNumber;
+      this.greeting = greeting;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      MDC.put("greeting_number", String.valueOf(this.taskNumber));
+
+      try {
+        printGreeting();
+      } catch (Exception e) {
+        LOGGER.error("Error in task: {}", taskNumber, e);
+      }
+      return null;
+    }
+
+    private void printGreeting() {
+      System.out.println(greeting.greeting());
+    }
+  }
+}

--- a/examples/rollbar-log4j2/src/main/java/com/rollbar/log4j2/example/Greeting.java
+++ b/examples/rollbar-log4j2/src/main/java/com/rollbar/log4j2/example/Greeting.java
@@ -1,0 +1,27 @@
+package com.rollbar.log4j2.example;
+
+import static java.lang.String.format;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Greeting class that generates different greetings throwing exceptions every even greeting message
+ * number.
+ */
+public class Greeting {
+
+  private static AtomicInteger counter = new AtomicInteger(1);
+
+  /**
+   * Get the greeting message.
+   * @return the greeting message.
+   */
+  public String greeting() {
+    int current = counter.getAndAdd(1);
+
+    if (current % 2 != 0) {
+      return format("Hello Rollbar number %d", current);
+    }
+    throw new RuntimeException("Fatal error at greeting number: " + current);
+  }
+}

--- a/examples/rollbar-log4j2/src/main/resources/log4j2.xml
+++ b/examples/rollbar-log4j2/src/main/resources/log4j2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+    </Console>
+    <Rollbar name="ROLLBAR">
+      <accessToken>[ACCESS_TOKEN]</accessToken>>
+    </Rollbar>
+  </Appenders>
+
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="Console" />
+    </Root>
+    <Logger name="com.example.rollbar.log4j2" level="DEBUG" additivity="false">
+      <AppenderRef ref="ROLLBAR"/>
+    </Logger>
+  </Loggers>
+</Configuration>

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Level.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Level.java
@@ -49,7 +49,7 @@ public enum Level implements Comparable<Level>, JsonSerializable {
   }
 
   public static Level lookupByName(String name) {
-    return name != null ? nameIndex.get(name) : null;
+    return name != null ? nameIndex.get(name.toLowerCase()) : null;
   }
 
   /**

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/LevelTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/LevelTest.java
@@ -1,0 +1,44 @@
+package com.rollbar.api.payload.data;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class LevelTest {
+
+  @Parameter
+  public String name;
+
+  @Parameter(1)
+  public Level expected;
+
+  @Parameters(name = "{index}: name({0}) is level({1})")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { "critical", Level.CRITICAL },
+        { "error", Level.ERROR },
+        { "warning", Level.WARNING },
+        { "info", Level.INFO },
+        { "debug", Level.DEBUG },
+        { "CRITICAL",  Level.CRITICAL },
+        { "ERROR", Level.ERROR },
+        { "WARNING", Level.WARNING },
+        { "INFO", Level.INFO },
+        { "DEBUG", Level.DEBUG },
+        { "no_exist", null }
+    });
+  }
+
+  @Test
+  public void shouldGetLevelByName() {
+    assertThat(Level.lookupByName(name), is(expected));
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -8,6 +8,8 @@ import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.config.ConfigProvider;
 import com.rollbar.notifier.uncaughtexception.RollbarUncaughtExceptionHandler;
 import com.rollbar.notifier.util.BodyFactory;
+import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
+import com.rollbar.notifier.wrapper.ThrowableWrapper;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.HashMap;
 import java.util.Map;
@@ -575,6 +577,30 @@ public class Rollbar {
    */
   public void log(Throwable error, Map<String, Object> custom, String description, Level level,
       boolean isUncaught) {
+    RollbarThrowableWrapper rollbarThrowableWrapper = null;
+
+    if (error != null) {
+      rollbarThrowableWrapper = new RollbarThrowableWrapper(error);
+
+    }
+    this.log(rollbarThrowableWrapper, custom, description, level, isUncaught);
+  }
+
+  /**
+   * Record an error or message with extra data at the level specified. At least ene of `error` or
+   * `description` must be non-null. If error is null, `description` will be sent as a message. If
+   * error is non-null, description will be sent as the description of the error. Custom data will
+   * be attached to message if the error is null. Custom data will extend whatever {@link
+   * Config#custom} returns.
+   *
+   * @param error the error (if any).
+   * @param custom the custom data (if any).
+   * @param description the description of the error, or the message to send.
+   * @param level the level to send it at.
+   * @param isUncaught whether or not this data comes from an uncaught exception.
+   */
+  public void log(ThrowableWrapper error, Map<String, Object> custom, String description,
+                  Level level, boolean isUncaught) {
     try {
       process(error, custom, description, level, isUncaught);
     } catch (Exception e) {
@@ -599,8 +625,7 @@ public class Rollbar {
     return Level.ERROR;
   }
 
-
-  private void process(Throwable error, Map<String, Object> custom, String description,
+  private void process(ThrowableWrapper error, Map<String, Object> custom, String description,
       Level level, boolean isUncaught) {
     this.configReadLock.lock();
     Config config = this.config;
@@ -612,7 +637,8 @@ public class Rollbar {
     }
     
     // Pre filter
-    if (config.filter() != null && config.filter().preProcess(level, error, custom, description)) {
+    if (config.filter() != null && config.filter().preProcess(level, error.getThrowable(), custom,
+        description)) {
       LOGGER.debug("Pre-filtered error: {}", error);
       return;
     }
@@ -662,7 +688,7 @@ public class Rollbar {
     sendPayload(config, payload);
   }
 
-  private Data buildData(Config config, Throwable error, Map<String, Object> custom,
+  private Data buildData(Config config, ThrowableWrapper error, Map<String, Object> custom,
       String description, Level level, boolean isUncaught) {
 
     Data.Builder dataBuilder = new Data.Builder()
@@ -671,7 +697,8 @@ public class Rollbar {
         .platform(config.platform())
         .language(config.language())
         .framework(config.framework())
-        .level(level != null ? level : level(error))
+        .level(level != null ? level : error != null ? level(error.getThrowable())
+            : level(null))
         .body(bodyFactory.from(error, description))
         .isUncaught(isUncaught);
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
@@ -1,0 +1,114 @@
+package com.rollbar.notifier.wrapper;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Implementation of the {@link ThrowableWrapper throwable wrapper}.
+ */
+public class RollbarThrowableWrapper implements ThrowableWrapper {
+
+  private final String className;
+
+  private final String message;
+
+  private final StackTraceElement[] stackTraceElements;
+
+  private final ThrowableWrapper cause;
+
+  private final Throwable throwable;
+
+  /**
+   * Constructor.
+   *
+   * @param throwable the throwable.
+   */
+  public RollbarThrowableWrapper(Throwable throwable) {
+    this(throwable.getClass().getName(), throwable.getMessage(), throwable.getStackTrace(),
+        throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
+        throwable);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param className the class name.
+   * @param message the message.
+   * @param stackTraceElements the stack trace elements.
+   * @param cause the cause.
+   */
+  public RollbarThrowableWrapper(String className, String message,
+      StackTraceElement[] stackTraceElements,
+      ThrowableWrapper cause) {
+    this(className, message, stackTraceElements, cause, null);
+  }
+
+  private RollbarThrowableWrapper(String className, String message, StackTraceElement[] stackTraceElements,
+      ThrowableWrapper cause, Throwable throwable) {
+    this.className = className;
+    this.message = message;
+    this.stackTraceElements = stackTraceElements;
+    this.cause = cause;
+    this.throwable = throwable;
+  }
+
+  @Override
+  public String getClassName() {
+    return this.className;
+  }
+
+  @Override
+  public String getMessage() {
+    return this.message;
+  }
+
+  @Override
+  public StackTraceElement[] getStackTrace() {
+    return Arrays.copyOf(stackTraceElements, stackTraceElements.length);
+  }
+
+  @Override
+  public ThrowableWrapper getCause() {
+    return this.cause;
+  }
+
+  @Override
+  public Throwable getThrowable() {
+    return this.throwable;
+  }
+
+  @Override
+  public String toString() {
+    return "RollbarThrowableWrapper{"
+        + "className='" + className + '\''
+        + ", message='" + message + '\''
+        + ", stackTraceElements=" + Arrays.toString(stackTraceElements)
+        + ", cause=" + cause
+        + ", throwable=" + throwable
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RollbarThrowableWrapper that = (RollbarThrowableWrapper) o;
+    return Objects.equals(className, that.className)
+        && Objects.equals(message, that.message)
+        && Arrays.equals(stackTraceElements, that.stackTraceElements)
+        && Objects.equals(cause, that.cause)
+        && Objects.equals(throwable, that.throwable);
+  }
+
+  @Override
+  public int hashCode() {
+
+    int result = Objects.hash(className, message, cause, throwable);
+    result = 31 * result + Arrays.hashCode(stackTraceElements);
+    return result;
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/ThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/ThrowableWrapper.java
@@ -1,0 +1,42 @@
+package com.rollbar.notifier.wrapper;
+
+/**
+ * Throwable wrapper to wrap a {@link Throwable thowable} or to represent a not available one.
+ */
+public interface ThrowableWrapper {
+
+  /**
+   * Get the {@link Throwable throwable} class name.
+   *
+   * @return the class name.
+   */
+  String getClassName();
+
+  /**
+   * Get the {@link Throwable throwable} message.
+   *
+   * @return the message.
+   */
+  String getMessage();
+
+  /**
+   * Get the {@link Throwable throwable} stack trace elements.
+   *
+   * @return the stack trace elements.
+   */
+  StackTraceElement[] getStackTrace();
+
+  /**
+   * Get the {@link ThrowableWrapper throwable wrapped} cause.
+   *
+   * @return the cause.
+   */
+  ThrowableWrapper getCause();
+
+  /**
+   * Get the wrapped {@link Throwable throwable}.
+   *
+   * @return the throwable.
+   */
+  Throwable getThrowable();
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
@@ -4,12 +4,18 @@ import static com.rollbar.notifier.config.ConfigBuilder.withAccessToken;
 import static com.rollbar.notifier.config.ConfigBuilder.withConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.rollbar.api.payload.Payload;
 import com.rollbar.api.payload.data.Client;
@@ -28,14 +34,18 @@ import com.rollbar.notifier.sender.Sender;
 import com.rollbar.notifier.transformer.Transformer;
 import com.rollbar.notifier.util.BodyFactory;
 import com.rollbar.notifier.uuid.UuidGenerator;
+import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
+import com.rollbar.notifier.wrapper.ThrowableWrapper;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
 
 public class RollbarTest {
 
@@ -126,6 +136,8 @@ public class RollbarTest {
   public void shouldProcessAllInformation() {
     Level level = Level.ERROR;
     Throwable error = new RuntimeException("Something went wrong.");
+    ThrowableWrapper errorWrapper = new RollbarThrowableWrapper(error);
+
     Body body = mock(Body.class);
 
     String context = "context";
@@ -163,7 +175,7 @@ public class RollbarTest {
         .level(level)
         .build();
 
-    when(bodyFactory.from(eq(error), any())).thenReturn(body);
+    when(bodyFactory.from(eq(errorWrapper), anyString())).thenReturn(body);
     when(contextProvider.provide()).thenReturn(context);
     when(personProvider.provide()).thenReturn(person);
     when(serverProvider.provide()).thenReturn(server);
@@ -326,7 +338,8 @@ public class RollbarTest {
     Long timestamp = 1L;
 
     when(timestampProvider.provide()).thenReturn(timestamp);
-    when(bodyFactory.from(any(), any())).thenReturn(body);
+    when(bodyFactory.from(any(ThrowableWrapper.class), eq(description))).thenReturn(body);
+    when(bodyFactory.from((ThrowableWrapper) null, description)).thenReturn(body);
 
     Rollbar sut = new Rollbar(config, bodyFactory);
 
@@ -413,17 +426,18 @@ public class RollbarTest {
         .language(LANGUAGE);
 
     Body bodyOnlyError = mock(Body.class);
-    Body bodyOnlyDescription = mock(Body.class);
-    Body body = mock(Body.class);
+    final Body bodyOnlyDescription = mock(Body.class);
+    final Body body = mock(Body.class);
 
     Throwable error = new RuntimeException("The error");
+    ThrowableWrapper errorWrapper = new RollbarThrowableWrapper(error);
     String description = "description";
     Map<String, Object> custom = new HashMap<>();
     custom.put("param1", "value1");
 
-    when(bodyFactory.from(error, null)).thenReturn(bodyOnlyError);
-    when(bodyFactory.from(null, description)).thenReturn(bodyOnlyDescription);
-    when(bodyFactory.from(error, description)).thenReturn(body);
+    when(bodyFactory.from(errorWrapper, null)).thenReturn(bodyOnlyError);
+    when(bodyFactory.from((ThrowableWrapper) null, description)).thenReturn(bodyOnlyDescription);
+    when(bodyFactory.from(errorWrapper, description)).thenReturn(body);
 
     sut.log(error);
     verify(sender).send(payloadBuilder.data(dataBuilder
@@ -526,13 +540,15 @@ public class RollbarTest {
     Body body = mock(Body.class);
 
     Throwable error = new RuntimeException("The error");
+    ThrowableWrapper errorWrapper = new RollbarThrowableWrapper(error);
+
     String description = "description";
     Map<String, Object> custom = new HashMap<>();
     custom.put("param1", "value1");
 
-    when(bodyFactory.from(error, null)).thenReturn(bodyOnlyError);
-    when(bodyFactory.from(null, description)).thenReturn(bodyOnlyDescription);
-    when(bodyFactory.from(error, description)).thenReturn(body);
+    when(bodyFactory.from(errorWrapper, null)).thenReturn(bodyOnlyError);
+    when(bodyFactory.from((ThrowableWrapper) null, description)).thenReturn(bodyOnlyDescription);
+    when(bodyFactory.from(errorWrapper, description)).thenReturn(body);
 
     switch (level) {
       case CRITICAL:

--- a/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
@@ -1,0 +1,54 @@
+package com.rollbar.notifier.wrapper;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RollbarThrowableWrapperTest {
+
+  @Test
+  public void shouldBeCreatedByThrowable() {
+    Throwable nestedThrowable = new IllegalStateException("This is the nested throwable message");
+    Throwable throwable = new IllegalArgumentException("This is the root throwable message", nestedThrowable);
+
+    ThrowableWrapper nested = new RollbarThrowableWrapper(nestedThrowable);
+    RollbarThrowableWrapper sut = new RollbarThrowableWrapper(throwable);
+
+    assertThat(sut.getClassName(), is(throwable.getClass().getName()));
+    assertThat(sut.getMessage(), is(throwable.getMessage()));
+    assertThat(sut.getStackTrace(), is(throwable.getStackTrace()));
+    assertThat(sut.getCause(), is(nested));
+    assertThat(sut.getThrowable(), is(throwable));
+  }
+
+  @Test
+  public void shouldBeCreatedByThrowableParams() {
+    String className = NullPointerException.class.getName();
+    String message = "This is the throwable message";
+    StackTraceElement[] elements = new StackTraceElement[1];
+    elements[0] = new StackTraceElement("className", "logMethod", "fileName",3);
+
+    ThrowableWrapper cause = new RollbarThrowableWrapper(new IllegalAccessError());
+
+    RollbarThrowableWrapper sut = new RollbarThrowableWrapper(className,message, elements, cause);
+
+    assertThat(sut.getClassName(), is(className));
+    assertThat(sut.getMessage(), is(message));
+    assertThat(sut.getStackTrace(), is(elements));
+    assertThat(sut.getCause(), is(cause));
+    assertThat(sut.getThrowable(), is(nullValue()));
+  }
+
+  @Test
+  public void shouldBeEqual() {
+    Throwable throwable = new IllegalArgumentException("This is the throwable message");
+
+    RollbarThrowableWrapper sut1 = new RollbarThrowableWrapper(throwable);
+    RollbarThrowableWrapper sut2 = new RollbarThrowableWrapper(throwable);
+
+    assertTrue(sut1.equals(sut2));
+  }
+}

--- a/rollbar-log4j2/build.gradle
+++ b/rollbar-log4j2/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    compile project(':rollbar-java')
+
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
+}

--- a/rollbar-log4j2/src/main/java/com/rollbar/log4j2/RollbarAppender.java
+++ b/rollbar-log4j2/src/main/java/com/rollbar/log4j2/RollbarAppender.java
@@ -1,0 +1,188 @@
+package com.rollbar.log4j2;
+
+import static com.rollbar.notifier.config.ConfigBuilder.withAccessToken;
+
+import com.rollbar.api.payload.data.Level;
+import com.rollbar.notifier.Rollbar;
+import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
+import com.rollbar.notifier.wrapper.ThrowableWrapper;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.util.Booleans;
+
+@Plugin(name = "Rollbar", category = Node.CATEGORY, elementType = Appender.ELEMENT_TYPE,
+    printObject = true)
+public class RollbarAppender extends AbstractAppender {
+
+  private static final String PACKAGE_NAME = "com.rollbar";
+
+  private static final String CUSTOM_NAMESPACE_KEY = "rollbar-log4j2";
+
+  private static final String CUSTOM_LOGGER_NAME_KEY = "loggerName";
+
+  private static final String CUSTOM_MDC_NAME_KEY = "mdc";
+
+  private static final String CUSTOM_NDC_NAME_KEY = "ndc";
+
+  private static final String CUSTOM_MAKER_NAME_KEY = "marker";
+
+  private static final String CUSTOM_THREAD_NAME_KEY = "threadName";
+
+  private Rollbar rollbar;
+
+  protected RollbarAppender(String name, Filter filter, Layout<? extends Serializable> layout,
+      boolean ignoreExceptions, Rollbar rollbar) {
+    super(name, filter, layout, ignoreExceptions);
+    this.rollbar = rollbar;
+  }
+
+  /**
+   * Create appender plugin factory method.
+   *
+   * @param accessToken the Rollbar access token.
+   * @param name the name.
+   * @param layout the layout.
+   * @param filter the filter.
+   * @param ignore the ignore exceptions flag.
+   * @return the rollbar appender.
+   */
+  @PluginFactory
+  public static RollbarAppender createAppender(
+      @PluginAttribute("accessToken") @Required final String accessToken,
+      @PluginAttribute("name") @Required final String name,
+      @PluginElement("Layout") Layout<? extends Serializable> layout,
+      @PluginElement("Filter") Filter filter,
+      @PluginAttribute("ignoreExceptions") final String ignore
+  ) {
+
+    Rollbar rollbar = new Rollbar(withAccessToken(accessToken).build());
+
+    boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
+
+    return new RollbarAppender(name, filter, layout, ignoreExceptions, rollbar);
+  }
+
+  @Override
+  public void append(LogEvent event) {
+    if (event.getLoggerName() != null && event.getLoggerName().startsWith(PACKAGE_NAME)) {
+      LOGGER.warn("Recursive logging from [{}] for appender [{}].", event.getLoggerName(),
+          getName());
+      return;
+    }
+
+    ThrowableProxy throwableProxy = event.getThrownProxy();
+    ThrowableWrapper rollbarThrowableWrapper = buildRollbarThrowableWrapper(throwableProxy);
+    Map<String, Object> custom = this.buildCustom(event);
+    String message = event.getMessage() != null ? event.getMessage().getFormattedMessage() : null;
+    Level level = this.getLevel(event);
+
+    rollbar.log(rollbarThrowableWrapper, custom, message, level, false);
+  }
+
+  private ThrowableWrapper buildRollbarThrowableWrapper(ThrowableProxy throwableProxy) {
+    if (throwableProxy == null) {
+      return null;
+    }
+
+    if (throwableProxy.getThrowable() != null) {
+      return new RollbarThrowableWrapper(throwableProxy.getThrowable());
+    }
+
+    String className = throwableProxy.getName();
+    String message = throwableProxy.getMessage();
+    ThrowableWrapper causeThrowableWrapper =
+        buildRollbarThrowableWrapper(throwableProxy.getCauseProxy());
+    StackTraceElement[] stackTraceElements = buildStackTraceElements(
+        throwableProxy.getStackTrace());
+
+    return new RollbarThrowableWrapper(className, message, stackTraceElements,
+        causeThrowableWrapper);
+  }
+
+  private StackTraceElement[] buildStackTraceElements(StackTraceElement[] stackTraceElements) {
+    StackTraceElement[] elements = new StackTraceElement[stackTraceElements.length];
+
+    for (int i = 0; i < stackTraceElements.length; i++) {
+      elements[i] = stackTraceElements[i];
+    }
+
+    return elements;
+  }
+
+  private Level getLevel(LogEvent event) {
+    org.apache.logging.log4j.Level level = event.getLevel();
+
+    Level rollbarLevel = Level.lookupByName(level.name());
+    if (rollbarLevel != null) {
+      return rollbarLevel;
+    }
+
+    if (org.apache.logging.log4j.Level.FATAL.equals(level)) {
+      return Level.CRITICAL;
+    }
+
+    return null;
+  }
+
+  private Map<String, Object> buildCustom(LogEvent event) {
+    Map<String, Object> custom = new HashMap<>();
+
+    custom.put(CUSTOM_LOGGER_NAME_KEY, event.getLoggerName());
+    custom.put(CUSTOM_THREAD_NAME_KEY, event.getThreadName());
+
+    custom.put(CUSTOM_MDC_NAME_KEY, this.buildMdc(event));
+    custom.put(CUSTOM_NDC_NAME_KEY, this.getNdc(event));
+    custom.put(CUSTOM_MAKER_NAME_KEY, this.getMarker(event));
+
+    Map<String, Object> rootCustom = new HashMap<>();
+    rootCustom.put(CUSTOM_NAMESPACE_KEY, custom);
+
+    return rootCustom;
+  }
+
+  private Map<String, Object> buildMdc(LogEvent event) {
+    if (event.getContextData() == null || event.getContextData().size() == 0) {
+      return null;
+
+    }
+
+    Map<String, Object> mdc = new HashMap<>();
+
+    for (Entry<String, String> mdcEntry : event.getContextData().toMap().entrySet()) {
+      mdc.put(mdcEntry.getKey(), mdcEntry.getValue());
+    }
+
+    return mdc;
+  }
+
+  private List<String> getNdc(LogEvent event) {
+    if (event.getContextStack() == null || event.getContextStack().size() == 0) {
+      return null;
+    }
+
+    return event.getContextStack().asList();
+  }
+
+  private String getMarker(LogEvent event) {
+    if (event.getMarker() == null) {
+      return null;
+    }
+
+    return event.getMarker().getName();
+  }
+}

--- a/rollbar-log4j2/src/test/java/com/rollbar/log4j2/RollbarAppenderTest.java
+++ b/rollbar-log4j2/src/test/java/com/rollbar/log4j2/RollbarAppenderTest.java
@@ -1,0 +1,237 @@
+package com.rollbar.log4j2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rollbar.api.payload.data.Level;
+import com.rollbar.notifier.Rollbar;
+import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
+import com.rollbar.notifier.wrapper.ThrowableWrapper;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.IllegalFormatException;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.ThreadContext.ContextStack;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class RollbarAppenderTest {
+
+  private static String EXCEPTION_MESSAGE = "This is the exception message";
+
+  private static final String FORMATTED_MESSAGE = "This is the logging message";
+
+  private static final String LOGGER_NAME = "rollbar-logger";
+
+  private static final String MARKER_NAME = "SQL_QUERY";
+
+  private static final String THREAD_NAME = "my-thread";
+
+  private static final Map<String, String> MDC = new HashMap<>();
+  static {
+    MDC.put("mdc_key_1", "mdc_value_1");
+  }
+
+  private static final List<String> NDC = Arrays.asList("ndc_value_1", "ndc_value_2");
+
+  private static String NESTED_EXCEPTION_MESSAGE = "This is the nested exception message";
+
+  private static final Exception NESTED_EXCEPTION =
+      new NullPointerException(NESTED_EXCEPTION_MESSAGE);
+
+  private static final Exception EXCEPTION =
+      new IllegalArgumentException(EXCEPTION_MESSAGE, NESTED_EXCEPTION);
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule();
+
+  private static final String APPENDER_NAME = "Rollbar";
+
+  private RollbarAppender sut;
+
+  @Mock
+  private Rollbar rollbar;
+
+  @Mock
+  private LogEvent event;
+
+  @Mock
+  private Marker marker;
+
+  @Mock
+  private Message message;
+
+  @Mock
+  private ReadOnlyStringMap contextData;
+
+  @Mock
+  private ContextStack contextStack;
+
+  @Before
+  public void setUp() {
+    when(marker.getName()).thenReturn(MARKER_NAME);
+    when(contextData.toMap()).thenReturn(new HashMap<>(MDC));
+    when(contextData.size()).thenReturn(MDC.size());
+    when(contextStack.asList()).thenReturn(NDC);
+    when(contextStack.size()).thenReturn(NDC.size());
+    when(message.getFormattedMessage()).thenReturn(FORMATTED_MESSAGE);
+
+    sut = new RollbarAppender(APPENDER_NAME, null, null, true, rollbar);
+  }
+
+  @Test
+  public void shouldNotLogIfLoggerIsRollbar() {
+    when(event.getLoggerName()).thenReturn("com.rollbar.any");
+
+    sut.append(event);
+
+    verify(rollbar, never()).log(any(ThrowableWrapper.class),
+        ArgumentMatchers.<String, Object>anyMap(), anyString(), any(Level.class), anyBoolean());
+
+  }
+
+  @Test
+  public void shouldLogEventWithAllInformationFromThrowableProxyWithThrowable() {
+    ThrowableWrapper throwableWrapper = new RollbarThrowableWrapper(EXCEPTION);
+
+    when(event.getLoggerName()).thenReturn(LOGGER_NAME);
+    when(event.getMarker()).thenReturn(marker);
+    when(event.getThreadName()).thenReturn(THREAD_NAME);
+    when(event.getLevel()).thenReturn(org.apache.logging.log4j.Level.ERROR);
+    when(event.getThrownProxy()).thenReturn(new ThrowableProxy(EXCEPTION));
+    when(event.getContextData()).thenReturn(contextData);
+    when(event.getContextStack()).thenReturn(contextStack);
+    when(event.getMessage()).thenReturn(message);
+
+    sut.append(event);
+
+    Map<String, Object> expectedCustom = buildExpectedCustom(LOGGER_NAME,
+        new HashMap<String, Object>(MDC), NDC, MARKER_NAME, THREAD_NAME);
+
+    verify(rollbar).log(throwableWrapper, expectedCustom, FORMATTED_MESSAGE, Level.ERROR, false);
+  }
+
+  @Test
+  public void shouldLogEventWithAllInformationFromThrowableProxyWithoutThrowable() {
+    ThrowableProxy throwableProxy = mock(ThrowableProxy.class);
+    when(throwableProxy.getThrowable()).thenReturn(null);
+    when(throwableProxy.getName()).thenReturn(EXCEPTION.getClass().getName());
+    when(throwableProxy.getMessage()).thenReturn(EXCEPTION.getMessage());
+    when(throwableProxy.getCauseProxy()).thenReturn(new ThrowableProxy(NESTED_EXCEPTION));
+    when(throwableProxy.getStackTrace()).thenReturn(EXCEPTION.getStackTrace());
+
+    ThrowableWrapper throwableWrapper = new RollbarThrowableWrapper(EXCEPTION.getClass().getName(),
+        EXCEPTION.getMessage(), EXCEPTION.getStackTrace(),
+        new RollbarThrowableWrapper(NESTED_EXCEPTION));
+
+    when(event.getLoggerName()).thenReturn(LOGGER_NAME);
+    when(event.getMarker()).thenReturn(marker);
+    when(event.getThreadName()).thenReturn(THREAD_NAME);
+    when(event.getLevel()).thenReturn(org.apache.logging.log4j.Level.ERROR);
+    when(event.getThrownProxy()).thenReturn(throwableProxy);
+    when(event.getContextData()).thenReturn(contextData);
+    when(event.getContextStack()).thenReturn(contextStack);
+    when(event.getMessage()).thenReturn(message);
+
+    sut.append(event);
+
+    Map<String, Object> expectedCustom = buildExpectedCustom(LOGGER_NAME,
+        new HashMap<String, Object>(MDC), NDC, MARKER_NAME, THREAD_NAME);
+
+    verify(rollbar).log(throwableWrapper, expectedCustom, FORMATTED_MESSAGE, Level.ERROR, false);
+  }
+
+  @Test
+  public void shouldLogEventWhenNoMarker() {
+    RollbarThrowableWrapper throwableWrapper = new RollbarThrowableWrapper(EXCEPTION);
+
+    when(event.getLoggerName()).thenReturn(LOGGER_NAME);
+    when(event.getThreadName()).thenReturn(THREAD_NAME);
+    when(event.getLevel()).thenReturn(org.apache.logging.log4j.Level.ERROR);
+    when(event.getThrownProxy()).thenReturn(new ThrowableProxy(EXCEPTION));
+    when(event.getContextData()).thenReturn(contextData);
+    when(event.getContextStack()).thenReturn(contextStack);
+    when(event.getMessage()).thenReturn(message);
+
+    sut.append(event);
+
+    Map<String, Object> expectedCustom = buildExpectedCustom(LOGGER_NAME,
+        new HashMap<String, Object>(MDC), NDC, null, THREAD_NAME);
+
+    verify(rollbar).log(throwableWrapper, expectedCustom, FORMATTED_MESSAGE, Level.ERROR, false);
+  }
+
+  @Test
+  public void shouldLogEventWhenNoMDC() {
+    RollbarThrowableWrapper throwableWrapper = new RollbarThrowableWrapper(EXCEPTION);
+
+    when(event.getLoggerName()).thenReturn(LOGGER_NAME);
+    when(event.getMarker()).thenReturn(marker);
+    when(event.getThreadName()).thenReturn(THREAD_NAME);
+    when(event.getLevel()).thenReturn(org.apache.logging.log4j.Level.ERROR);
+    when(event.getThrownProxy()).thenReturn(new ThrowableProxy(EXCEPTION));
+    when(event.getContextData()).thenReturn(null);
+    when(event.getContextStack()).thenReturn(contextStack);
+    when(event.getMessage()).thenReturn(message);
+
+    sut.append(event);
+
+    Map<String, Object> expectedCustom = buildExpectedCustom(LOGGER_NAME,
+        null, NDC, MARKER_NAME, THREAD_NAME);
+
+    verify(rollbar).log(throwableWrapper, expectedCustom, FORMATTED_MESSAGE, Level.ERROR, false);
+  }
+
+  @Test
+  public void shouldLogEventWhenNoNDC() {
+    RollbarThrowableWrapper throwableWrapper = new RollbarThrowableWrapper(EXCEPTION);
+
+    when(event.getLoggerName()).thenReturn(LOGGER_NAME);
+    when(event.getMarker()).thenReturn(marker);
+    when(event.getThreadName()).thenReturn(THREAD_NAME);
+    when(event.getLevel()).thenReturn(org.apache.logging.log4j.Level.ERROR);
+    when(event.getThrownProxy()).thenReturn(new ThrowableProxy(EXCEPTION));
+    when(event.getContextData()).thenReturn(contextData);
+    when(event.getContextStack()).thenReturn(null);
+    when(event.getMessage()).thenReturn(message);
+
+    sut.append(event);
+
+    Map<String, Object> expectedCustom = buildExpectedCustom(LOGGER_NAME,
+        new HashMap<String, Object>(MDC), null, MARKER_NAME, THREAD_NAME);
+
+    verify(rollbar).log(throwableWrapper, expectedCustom, FORMATTED_MESSAGE, Level.ERROR, false);
+  }
+
+  private static Map<String, Object> buildExpectedCustom(String loggerName, Map<String, Object> mdc,
+      List<String> ndc, String markerName, String threadName) {
+    Map<String, Object> rootCustom = new HashMap<>();
+    Map<String, Object> custom = new HashMap<>();
+
+    custom.put("loggerName", loggerName);
+    custom.put("threadName", threadName);
+    custom.put("marker", markerName);
+    custom.put("mdc", mdc);
+    custom.put("ndc", ndc);
+
+    rootCustom.put("rollbar-log4j2", custom);
+
+    return rootCustom;
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,9 @@ include ":rollbar-api",
         ":rollbar-java",
         ":rollbar-android",
         ":rollbar-web",
+        ":rollbar-log4j2",
         ":examples:rollbar-java",
         ":examples:rollbar-web",
         ":examples:rollbar-android",
-        ":examples:rollbar-scala"
+        ":examples:rollbar-scala",
+        ":examples:rollbar-log4j2"


### PR DESCRIPTION
This PR includes these changes:

* Make `Level.lookupByName` to be case insensitive.
* Add `ThrowableWrapper` to represent a `Throwable` that is not available.
* Deprecate in BodyFactory the `from` method that uses the `Throwable` in favor of the new `from` that uses the `ThrowableWrapper`.
* Overload in `Rollbar` the log method with a version that receives a `ThrowableWraper`.
* Add the log4j2 integration with the log4j2 appender.