### PR TITLE
Remove java.nio.charset.StandardCharsets dependency by replacing the UTF-8 charset by a string constant

### DIFF
--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
@@ -13,7 +13,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Synchronous implementation of the {@link Sender sender}.
@@ -22,7 +21,7 @@ public class SyncSender extends AbstractSender {
 
   public static final String DEFAULT_API_ENDPOINT = "https://api.rollbar.com/api/1/item/";
 
-  private static final String UTF_8 = StandardCharsets.UTF_8.name();
+  private static final String UTF_8 = "UTF-8";
 
   private final URL url;
 

--- a/rollbar-java/src/test/java/com/rollbar/notifier/sender/SyncSenderTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/sender/SyncSenderTest.java
@@ -1,6 +1,5 @@
 package com.rollbar.notifier.sender;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -32,6 +31,8 @@ import org.mockito.junit.MockitoRule;
 
 public class SyncSenderTest {
 
+  static final String UTF_8 = "UTF-8";
+  
   static final String PAYLOAD_JSON = "simulated_payload_json";
 
   @Rule
@@ -159,8 +160,8 @@ public class SyncSenderTest {
   }
 
   private void verifyHttp() throws Exception {
-    verify(connection).setRequestProperty("Accept-Charset", UTF_8.name());
-    verify(connection).setRequestProperty("Content-Type", "application/json; charset=" + UTF_8.name());
+    verify(connection).setRequestProperty("Accept-Charset", UTF_8);
+    verify(connection).setRequestProperty("Content-Type", "application/json; charset=" + UTF_8);
     verify(connection).setRequestProperty("Accept", "application/json");
     verify(connection).setDoOutput(true);
     verify(connection).setRequestMethod("POST");


### PR DESCRIPTION
It seems that this is not available in Android 4.3 and lower.

Fix #115 