### PR TITLE
Add support for configuring the rollbar url

### DIFF
--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java
@@ -27,6 +27,13 @@ public interface Config {
   String accessToken();
 
   /**
+   * Get the url.
+   *
+   * @return the Rollbar url.
+   */
+  String url();
+
+  /**
    * Get the environment.
    *
    * @return the environment.

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
@@ -27,6 +27,8 @@ public class ConfigBuilder {
 
   private String accessToken;
 
+  private String url;
+
   private String environment;
 
   private String codeVersion;
@@ -103,6 +105,7 @@ public class ConfigBuilder {
     this.sender = config.sender();
     this.handleUncaughtErrors = config.handleUncaughtErrors();
     this.enabled = config.isEnabled();
+    this.url = config.url();
   }
 
   /**
@@ -131,6 +134,17 @@ public class ConfigBuilder {
    */
   public ConfigBuilder accessToken(String accessToken) {
     this.accessToken = accessToken;
+    return this;
+  }
+
+  /**
+   * The Rollbar url to use.
+   *
+   * @param url the Rollbar url endpoint.
+   * @return the builder instance.
+   */
+  public ConfigBuilder url(String url) {
+    this.url = url;
     return this;
   }
 
@@ -363,9 +377,10 @@ public class ConfigBuilder {
       this.notifier = new NotifierProvider();
     }
     if (this.sender == null) {
-      this.sender = new BufferedSender.Builder()
+      this.sender =
+        new BufferedSender.Builder()
           .sender(
-            new SyncSender.Builder()
+            new SyncSender.Builder(this.url)
             .accessToken(accessToken)
             .build()
       ).build();
@@ -380,6 +395,8 @@ public class ConfigBuilder {
   private static class ConfigImpl implements Config {
 
     private final String accessToken;
+
+    private final String url;
 
     private final String environment;
 
@@ -423,6 +440,7 @@ public class ConfigBuilder {
 
     ConfigImpl(ConfigBuilder builder) {
       this.accessToken = builder.accessToken;
+      this.url = builder.url;
       this.environment = builder.environment;
       this.codeVersion = builder.codeVersion;
       this.platform = builder.platform;
@@ -448,6 +466,11 @@ public class ConfigBuilder {
     @Override
     public String accessToken() {
       return accessToken;
+    }
+
+    @Override
+    public String url() {
+      return url;
     }
 
     @Override

--- a/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
+++ b/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
@@ -8,6 +8,7 @@ import ch.qos.logback.classic.spi.StackTraceElementProxy;
 import ch.qos.logback.core.AppenderBase;
 import com.rollbar.api.payload.data.Level;
 import com.rollbar.notifier.Rollbar;
+import com.rollbar.notifier.config.Config;
 import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
 import com.rollbar.notifier.wrapper.ThrowableWrapper;
 import java.util.HashMap;
@@ -32,19 +33,31 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
 
   private String accessToken;
 
-  /**
-   * Constructor for testing purposes.
-   *
-   * @param rollbar the rollbar notifier.
-   */
-  protected RollbarAppender(Rollbar rollbar) {
-    this.rollbar = rollbar;
-  }
+  private String url;
+
+  private String environment;
+
+  private String language;
+
+//  /**
+//   * Constructor for testing purposes.
+//   *
+//   * @param rollbar the rollbar notifier.
+//   */
+//  protected RollbarAppender(Rollbar rollbar) {
+//    this.rollbar = rollbar;
+//  }
 
   @Override
   public void start() {
-    this.rollbar = new Rollbar(withAccessToken(this.accessToken).build());
+    Config config = withAccessToken(this.accessToken)
+            .environment(this.environment)
+            .url(this.url)
+            .server(new ServerProvider())
+            .language(this.language)
+            .build();
 
+    this.rollbar = new Rollbar(config);
     super.start();
   }
 
@@ -71,6 +84,18 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
    */
   public void setAccessToken(String accessToken) {
     this.accessToken = accessToken;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public void setEnvironment(String environment) {
+    this.environment = environment;
+  }
+
+  public void setLanguage(String language) {
+    this.language = language;
   }
 
   private ThrowableWrapper buildRollbarThrowableWrapper(IThrowableProxy throwableProxy) {

--- a/rollbar-logback/src/main/java/com/rollbar/logback/ServerProvider.java
+++ b/rollbar-logback/src/main/java/com/rollbar/logback/ServerProvider.java
@@ -1,0 +1,27 @@
+package com.rollbar.logback;
+
+import com.rollbar.api.payload.data.Server;
+import com.rollbar.notifier.provider.Provider;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Server provider that populates the server's hostname
+ */
+public class ServerProvider implements Provider<Server> {
+
+    @Override
+    public Server provide() {
+        try {
+            InetAddress host = InetAddress.getLocalHost();
+            return new Server.Builder()
+                    .host(host.getHostName())
+                    .build();
+        } catch (UnknownHostException e) {
+            return new Server.Builder()
+                    .host("localhost")
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
More than one rollbar url can be used by a company e.g. have different urls for different regions us, eu etc.

Added the **url** field in the `Config` interface to be further used in the _rollbar-logback_
module when setting a custom rollbar url (e.g. region specific rollar-us, rollbar-eu).

In _RollbarAppender_, added the possibility to customise the **environment**,
**language** (it can be `scala` for example) and to report the **server hostname**.