### PR TITLE
Do not throw “invalid access token” if it’s empty or is an spring-boot environment variable

### DIFF
--- a/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
+++ b/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
@@ -62,24 +62,29 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
   @Override
   public void start() {
 
-    ConfigProvider configProvider = ConfigProviderHelper
-            .getConfigProvider(this.configProviderClassName);
-    Config config;
-
-    ConfigBuilder configBuilder = withAccessToken(this.accessToken)
-            .environment(this.environment)
-            .endpoint(this.endpoint)
-            .server(new ServerProvider())
-            .language(this.language);
-
-    if (configProvider != null) {
-      config = configProvider.provide(configBuilder);
-    } else {
-      config = configBuilder.build();
+    if (this.accessToken != null && !this.accessToken.endsWith("IS_UNDEFINED")){
+      
+      ConfigProvider configProvider = ConfigProviderHelper
+              .getConfigProvider(this.configProviderClassName);
+      Config config;
+  
+      ConfigBuilder configBuilder = withAccessToken(this.accessToken)
+              .environment(this.environment)
+              .endpoint(this.endpoint)
+              .server(new ServerProvider())
+              .language(this.language);
+  
+      if (configProvider != null) {
+        config = configProvider.provide(configBuilder);
+      } else {
+        config = configBuilder.build();
+      }
+  
+      this.rollbar = new Rollbar(config);
+      super.start();
+    
     }
-
-    this.rollbar = new Rollbar(config);
-    super.start();
+    
   }
 
   @Override


### PR DESCRIPTION
How about avoiding this:

```java
com.rollbar.notifier.sender.exception.SenderException: com.rollbar.notifier.sender.exception.ApiException: invalid access token
	at com.rollbar.notifier.sender.AbstractSender.send(AbstractSender.java:41)
	at com.rollbar.notifier.sender.BufferedSender$SendTask.run(BufferedSender.java:217)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: com.rollbar.notifier.sender.exception.ApiException: invalid access token
	... 9 common frames omitted
```

When:

```xml
<appender name="ROLLBAR" class="com.rollbar.logback.RollbarAppender">
	<accessToken>${rollbar.api.key}</accessToken>
	...
</appender
```

Because:

Devs usually don't send exceptions to Rollbar when they are in development environment. Only the production server has the ${rollbar.api.key} variable. This code helps to avoid using that boring `janino ` ifs...

