### PR TITLE
Fix android proguard warnings

### DIFF
--- a/rollbar-android/build.gradle
+++ b/rollbar-android/build.gradle
@@ -23,6 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 27
+        consumerProguardFiles 'proguard-rules.pro'
     }
 }
 

--- a/rollbar-android/proguard-rules.pro
+++ b/rollbar-android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn org.slf4j.**


### PR DESCRIPTION
After adding rollbar (v1.3.1) to my project the builds failed with the following messages:
```
Warning: org.slf4j.LoggerFactory: can't find referenced class org.slf4j.impl.StaticLoggerBinder
Warning: org.slf4j.MDC: can't find referenced class org.slf4j.impl.StaticMDCBinder
Warning: org.slf4j.MarkerFactory: can't find referenced class org.slf4j.impl.StaticMarkerBinder
```

After adding `-dontwarn org.slf4j.** ` to the proguard rules everything worked fine.

So maybe define this rule as a library rule to avoid other users facing this issue.