### PR TITLE
Close default Sender if custom implementation is used

### DIFF
--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -17,6 +17,7 @@ import com.rollbar.notifier.config.Config;
 import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.sender.BufferedSender;
 import com.rollbar.notifier.sender.queue.DiskQueue;
+import com.rollbar.notifier.util.ObjectsUtils;
 
 
 import java.io.File;
@@ -266,6 +267,10 @@ public class Rollbar {
       config = configProvider.provide(defaultConfig);
     } else {
       config = defaultConfig.build();
+    }
+
+    if (config.sender() != sender) {
+      ObjectsUtils.close(sender);
     }
 
     this.rollbar = new com.rollbar.notifier.Rollbar(config);


### PR DESCRIPTION
The default `Sender` will start scheduling its queue observer right in the constructor, which may conflict with a custom `Sender` provided through `ConfigProvider`. If the configured instance doesn’t match the default, the latter is closed again immediately.

Resolves https://github.com/rollbar/rollbar-java/issues/167 by closing the default instance when a custom one is given, too.