### PR TITLE
Provide convenience setter for JsonSerializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+gather.sh
+
 # Compiled source #
 ###################
 *.com

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
@@ -430,7 +430,7 @@ public class ConfigBuilder {
     }
     if (this.sender == null) {
       SyncSender.Builder innerSender =
-        new SyncSender.Builder(this.endpoint)
+          new SyncSender.Builder(this.endpoint)
           .accessToken(accessToken)
           .proxy(proxy);
       if (this.jsonSerializer != null) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
@@ -14,6 +14,7 @@ import com.rollbar.notifier.provider.timestamp.TimestampProvider;
 import com.rollbar.notifier.sender.BufferedSender;
 import com.rollbar.notifier.sender.Sender;
 import com.rollbar.notifier.sender.SyncSender;
+import com.rollbar.notifier.sender.json.JsonSerializer;
 import com.rollbar.notifier.transformer.Transformer;
 import com.rollbar.notifier.uuid.UuidGenerator;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -67,6 +68,8 @@ public class ConfigBuilder {
   private UuidGenerator uuidGenerator;
 
   private Sender sender;
+
+  private JsonSerializer jsonSerializer;
 
   private Proxy proxy;
 
@@ -354,6 +357,19 @@ public class ConfigBuilder {
   }
 
   /**
+   * The JsonSerializer to use with the default Sender if no other
+   * sender is specified. If a sender is specified then this
+   * parameter is ignored.
+   *
+   * @param jsonSerializer the json serializer.
+   * @return the builder instance.
+   */
+  public ConfigBuilder jsonSerializer(JsonSerializer jsonSerializer) {
+    this.jsonSerializer = jsonSerializer;
+    return this;
+  }
+
+  /**
    * The {@link Proxy proxy} to be used to send the data.
    *
    * @param proxy the proxy.
@@ -413,14 +429,15 @@ public class ConfigBuilder {
       this.notifier = new NotifierProvider();
     }
     if (this.sender == null) {
+      SyncSender.Builder innerSender =
+        new SyncSender.Builder(this.endpoint)
+          .accessToken(accessToken)
+          .proxy(proxy);
+      if (this.jsonSerializer != null) {
+        innerSender.jsonSerializer(this.jsonSerializer);
+      }
       this.sender =
-        new BufferedSender.Builder()
-          .sender(
-            new SyncSender.Builder(this.endpoint)
-            .accessToken(accessToken)
-            .proxy(proxy)
-            .build()
-      ).build();
+        new BufferedSender.Builder().sender(innerSender.build()).build();
     }
     if (this.timestamp == null) {
       this.timestamp = new TimestampProvider();


### PR DESCRIPTION
Fixes #164

The default sender is built with a default json serializer. If you do
not specify a sender there is currently no way to customize the json
serializer. This introduces a method `jsonSerializer` on the config
builder to set this value on the default constructed sender. If a sender
is already provided then this json serializer is ignored.