### PR TITLE
Allow the maximum number of logcat lines to be configured 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+gather.sh
+
 # Compiled source #
 ###################
 *.com

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -213,6 +213,22 @@ public class Rollbar {
    * @param captureIp one of: full, anonymize, none. This determines how the remote ip is captured.
    */
   public Rollbar(Context context, String accessToken, String environment, boolean registerExceptionHandler, boolean includeLogcat, ConfigProvider configProvider, String captureIp) {
+    this(context, accessToken, environment, registerExceptionHandler, includeLogcat, configProvider, captureIp, -1);
+  }
+
+  /**
+   * Construct a new Rollbar instance.
+   *
+   * @param context Android context to use.
+   * @param accessToken a Rollbar access token with at least post_client_item scope
+   * @param environment the environment to set for items
+   * @param registerExceptionHandler whether or not to handle uncaught exceptions.
+   * @param includeLogcat whether or not to include logcat output with items
+   * @param configProvider a configuration provider that can be used to customize the configuration further.
+   * @param captureIp one of: full, anonymize, none. This determines how the remote ip is captured.
+   * @param maxLogcatSize the maximum number of logcat lines to capture with items (ignored unless >= 0)
+   */
+  public Rollbar(Context context, String accessToken, String environment, boolean registerExceptionHandler, boolean includeLogcat, ConfigProvider configProvider, String captureIp, int maxLogcatSize) {
     if (accessToken == null) {
       try {
         accessToken = loadAccessTokenFromManifest(context);
@@ -236,6 +252,7 @@ public class Rollbar {
         .versionName(versionName)
         .includeLogcat(includeLogcat)
         .captureIp(captureIp)
+        .maxLogcatSize(maxLogcatSize)
         .build();
 
     environment = environment == null ? DEFAULT_ENVIRONMENT : environment;

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -255,8 +255,6 @@ public class Rollbar {
         .maxLogcatSize(maxLogcatSize)
         .build();
 
-    environment = environment == null ? DEFAULT_ENVIRONMENT : environment;
-
     File folder = new File(context.getCacheDir(), ITEM_DIR_NAME);
 
     ConfigBuilder defaultConfig = ConfigBuilder.withAccessToken(accessToken)
@@ -264,7 +262,7 @@ public class Rollbar {
         .platform(ANDROID)
         .framework(ANDROID)
         .notifier(new NotifierProvider(NOTIFIER_VERSION))
-        .environment(environment)
+        .environment(environment == null ? DEFAULT_ENVIRONMENT : environment)
         .handleUncaughtErrors(registerExceptionHandler);
 
     Config config;

--- a/rollbar-android/src/main/java/com/rollbar/android/provider/ClientProvider.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/provider/ClientProvider.java
@@ -19,14 +19,13 @@ public class ClientProvider implements Provider<Client> {
     private final String versionName;
     private boolean includeLogcat;
     private final int captureIp;
+    private final int maxLogcatSize;
 
     private static final String CAPTURE_IP_ANONYMIZE = "anonymize";
     private static final String CAPTURE_IP_NONE = "none";
     private static final int CAPTURE_IP_TYPE_FULL = 0;
     private static final int CAPTURE_IP_TYPE_ANONYMIZE = 1;
     private static final int CAPTURE_IP_TYPE_NONE = 2;
-
-    private static final int MAX_LOGCAT_SIZE = 100;
 
     /**
      * Constructor.
@@ -46,6 +45,7 @@ public class ClientProvider implements Provider<Client> {
         } else {
           this.captureIp = CAPTURE_IP_TYPE_FULL;
         }
+        this.maxLogcatSize = builder.maxLogcatSize;
     }
 
     @Override
@@ -92,7 +92,7 @@ public class ClientProvider implements Provider<Client> {
             while ((line = br.readLine()) != null) {
                 if (line.contains(String.valueOf(pid))) {
                     lines.add(line);
-                    if (lines.size() > MAX_LOGCAT_SIZE) {
+                    if (lines.size() > this.maxLogcatSize) {
                         lines.remove(0);
                     }
                 }
@@ -112,6 +112,14 @@ public class ClientProvider implements Provider<Client> {
         private String versionName;
         private boolean includeLogcat;
         private String captureIp;
+        private int maxLogcatSize;
+
+        /**
+         * Constructor.
+         */
+        public Builder() {
+            this.maxLogcatSize = 100;
+        }
 
         /**
          * The Android version code from the context
@@ -150,6 +158,18 @@ public class ClientProvider implements Provider<Client> {
          */
         public Builder captureIp(String captureIp) {
             this.captureIp = captureIp;
+            return this;
+        }
+
+        /**
+         * The maximum number of logcat lines to capture if logcat capturing is on.
+         * @param maxLogcatSize the max number of lines to capture
+         * @return the builder instance
+         */
+        public Builder maxLogcatSize(int maxLogcatSize) {
+            if (maxLogcatSize >= 0) {
+                this.maxLogcatSize = maxLogcatSize;
+            }
             return this;
         }
 


### PR DESCRIPTION
Fixes #173

We allow turning on/off including logcat lines with items for Android,
but currently the maximum number of lines is hardcoded to 100. This adds
an option to configure the limit with the default still being 100.