### PR TITLE
Add configuration to determine default item level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+gather.sh
+
 # Compiled source #
 ###################
 *.com

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -618,9 +618,13 @@ public class Rollbar {
   }
 
   /**
-   * Get the level of the error or message. By default: CRITICAL for {@link Error}, ERROR for other
-   * {@link Throwable}, WARNING for messages. Override to change this default.
+   * Get the level of the error or message. The Config passed in contains the defaults
+   * to use for the cases of an Error, Throwable, or a Message. The default in the Config
+   * if otherwise left unspecified is: CRITICAL for {@link Error}, ERROR for other
+   * {@link Throwable}, WARNING for messages. Use the methods on ConfigBuilder to
+   * change these defaults
    *
+   * @param config the current Config.
    * @param error the error.
    * @return the level.
    */

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -711,7 +711,7 @@ public class Rollbar {
         .language(config.language())
         .framework(config.framework())
         .level(level != null ? level : error != null ? level(config, error.getThrowable())
-            : level(null))
+            : level(config, null))
         .body(bodyFactory.from(error, description))
         .isUncaught(isUncaught);
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -624,14 +624,14 @@ public class Rollbar {
    * @param error the error.
    * @return the level.
    */
-  public Level level(Throwable error) {
+  public Level level(Config config, Throwable error) {
     if (error == null) {
-      return Level.WARNING;
+      return config.defaultMessageLevel();
     }
     if (error instanceof Error) {
-      return Level.CRITICAL;
+      return config.defaultErrorLevel();
     }
-    return Level.ERROR;
+    return config.defaultThrowableLevel();
   }
 
   public void close(boolean wait) throws Exception {
@@ -710,7 +710,7 @@ public class Rollbar {
         .platform(config.platform())
         .language(config.language())
         .framework(config.framework())
-        .level(level != null ? level : error != null ? level(error.getThrowable())
+        .level(level != null ? level : error != null ? level(config, error.getThrowable())
             : level(null))
         .body(bodyFactory.from(error, description))
         .isUncaught(isUncaught);

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java
@@ -1,6 +1,7 @@
 package com.rollbar.notifier.config;
 
 import com.rollbar.api.payload.data.Client;
+import com.rollbar.api.payload.data.Level;
 import com.rollbar.api.payload.data.Notifier;
 import com.rollbar.api.payload.data.Person;
 import com.rollbar.api.payload.data.Request;
@@ -188,4 +189,25 @@ public interface Config {
    * @return true if enabled otherwise false.
    */
   boolean isEnabled();
+
+  /**
+   * Level to use as the default for messages if one is not otherwise specified.
+   *
+   * @return the level.
+   */
+  Level defaultMessageLevel();
+
+  /**
+   * Level to use as the default for Errors if one is not otherwise specified.
+   *
+   * @return the level.
+   */
+  Level defaultErrorLevel();
+
+  /**
+   * Level to use as the default for non-Error Throwables if one is not otherwise specified.
+   *
+   * @return the level.
+   */
+  Level defaultThrowableLevel();
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
@@ -1,6 +1,7 @@
 package com.rollbar.notifier.config;
 
 import com.rollbar.api.payload.data.Client;
+import com.rollbar.api.payload.data.Level;
 import com.rollbar.api.payload.data.Notifier;
 import com.rollbar.api.payload.data.Person;
 import com.rollbar.api.payload.data.Request;
@@ -76,6 +77,12 @@ public class ConfigBuilder {
 
   private boolean enabled;
 
+  private Level defaultMessageLevel;
+
+  private Level defaultErrorLevel;
+
+  private Level defaultThrowableLevel;
+
   /**
    * Constructor with an access token.
    */
@@ -84,6 +91,9 @@ public class ConfigBuilder {
     this.accessToken = accessToken;
     this.handleUncaughtErrors = true;
     this.enabled = true;
+    this.defaultMessageLevel = Level.WARNING;
+    this.defaultErrorLevel = Level.CRITICAL;
+    this.defaultThrowableLevel = Level.ERROR;
   }
 
   /**
@@ -114,6 +124,9 @@ public class ConfigBuilder {
     this.endpoint = config.endpoint();
     this.proxy = config.proxy();
     this.appPackages = config.appPackages();
+    this.defaultMessageLevel = config.defaultMessageLevel();
+    this.defaultErrorLevel = config.defaultErrorLevel();
+    this.defaultThrowableLevel = config.defaultThrowableLevel();
   }
 
   /**
@@ -398,6 +411,39 @@ public class ConfigBuilder {
   }
 
   /**
+   * Level to use as the default for messages if one is not otherwise specified.
+   *
+   * @param level the level.
+   * @return the builder instance.
+   */
+  public ConfigBuilder defaultMessageLevel(Level level) {
+    this.defaultMessageLevel = level;
+    return this;
+  }
+
+  /**
+   * Level to use as the default for Errors if one is not otherwise specified.
+   *
+   * @param level the level.
+   * @return the builder instance.
+   */
+  public ConfigBuilder defaultErrorLevel(Level level) {
+    this.defaultErrorLevel = level;
+    return this;
+  }
+
+  /**
+   * Level to use as the default for non-Error Throwables if one is not otherwise specified.
+   *
+   * @param level the level.
+   * @return the builder instance.
+   */
+  public ConfigBuilder defaultThrowableLevel(Level level) {
+    this.defaultThrowableLevel = level;
+    return this;
+  }
+
+  /**
    * Builds the {@link Config config}.
    *
    * @return the config.
@@ -479,6 +525,12 @@ public class ConfigBuilder {
 
     private final boolean enabled;
 
+    private Level defaultMessageLevel;
+
+    private Level defaultErrorLevel;
+
+    private Level defaultThrowableLevel;
+
     ConfigImpl(ConfigBuilder builder) {
       this.accessToken = builder.accessToken;
       this.endpoint = builder.endpoint;
@@ -508,6 +560,9 @@ public class ConfigBuilder {
       }
       this.handleUncaughtErrors = builder.handleUncaughtErrors;
       this.enabled = builder.enabled;
+      this.defaultMessageLevel = builder.defaultMessageLevel;
+      this.defaultErrorLevel = builder.defaultErrorLevel;
+      this.defaultThrowableLevel = builder.defaultThrowableLevel;
     }
 
     @Override
@@ -628,6 +683,21 @@ public class ConfigBuilder {
     @Override
     public boolean isEnabled() {
       return enabled;
+    }
+
+    @Override
+    public Level defaultMessageLevel() {
+      return defaultMessageLevel;
+    }
+
+    @Override
+    public Level defaultErrorLevel() {
+      return defaultErrorLevel;
+    }
+
+    @Override
+    public Level defaultThrowableLevel() {
+      return defaultThrowableLevel;
     }
   }
 }

--- a/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
@@ -442,7 +442,7 @@ public class RollbarTest {
     sut.log(error);
     verify(sender).send(payloadBuilder.data(dataBuilder
         .body(bodyOnlyError)
-        .level(sut.level(error))
+        .level(sut.level(config, error))
         .build()
     ).build());
 
@@ -456,7 +456,7 @@ public class RollbarTest {
     sut.log(description);
     verify(sender).send(payloadBuilder.data(dataBuilder
         .body(bodyOnlyDescription)
-        .level(sut.level(null))
+        .level(sut.level(config, null))
         .build()
     ).build());
 
@@ -470,7 +470,7 @@ public class RollbarTest {
     sut.log(error, description);
     verify(sender).send(payloadBuilder.data(dataBuilder
         .body(body)
-        .level(sut.level(error))
+        .level(sut.level(config, error))
         .build()
     ).build());
 
@@ -484,7 +484,7 @@ public class RollbarTest {
     sut.log(error, custom);
     verify(sender).send(payloadBuilder.data(dataBuilder
         .body(bodyOnlyError)
-        .level(sut.level(error))
+        .level(sut.level(config, error))
         .custom(custom)
         .build()
     ).build());
@@ -501,7 +501,7 @@ public class RollbarTest {
     verify(sender).send(payloadBuilder.data(dataBuilder
         .body(bodyOnlyDescription)
         .custom(custom)
-        .level(sut.level(null))
+        .level(sut.level(config, null))
         .build()
     ).build());
 


### PR DESCRIPTION
Fixes #176

By default we use WARNING for messages, CRITICAL for Error type
throwables, and ERROR for other throwables. There is no way to change
that than always setting the level. This makes it so you can set the
default level in the configuration.