### PR TITLE
Enable sending complete JSON payloads, as proxy for other SDKs

### DIFF
--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -794,6 +794,15 @@ public class Rollbar {
   }
 
   /**
+  * Send payload to Rollbar.
+  *
+  * @param payload JSON payload string.
+  */
+  public void sendJsonPayload(String json) {
+    rollbar.sendJsonPayload(json);
+  }
+
+  /**
    * report an exception to Rollbar
    * @param throwable the exception that occurred.
    */

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/Payload.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/Payload.java
@@ -15,9 +15,23 @@ public class Payload implements JsonSerializable {
 
   private final Data data;
 
+  public final String json;
+
   private Payload(Builder builder) {
     this.accessToken = builder.accessToken;
     this.data = builder.data;
+    this.json = null;
+  }
+
+  /**
+    * Constructor.
+    *
+    * @param json the JSON payload.
+    */
+  public Payload(String json) {
+    this.accessToken = null;
+    this.data = null;
+    this.json = json;
   }
 
   /**

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/PayloadTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/PayloadTest.java
@@ -52,4 +52,13 @@ public class PayloadTest {
 
     assertEquals(expected, payload.asJson());
   }
+
+  @Test
+  public void shouldReturnJsonAsJson() {
+    String json = "{\"foo\":\"bar\"}";
+
+    Payload payload = new Payload(json);
+
+    assertEquals(json, payload.json);
+  }
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -642,6 +642,23 @@ public class Rollbar {
     this.config.sender().close(wait);
   }
 
+  /**
+   * Send JSON payload.
+   *
+   * @param json the json payload.
+   */
+  public void sendJsonPayload(String json) {
+    try {
+      this.configReadLock.lock();
+      Config config = this.config;
+      this.configReadLock.unlock();
+
+      sendPayload(config, new Payload(json));
+    } catch (Exception e) {
+      LOGGER.error("Error while sending payload to Rollbar: {}", e);
+    }
+  }
+
   private void process(ThrowableWrapper error, Map<String, Object> custom, String description,
       Level level, boolean isUncaught) {
     this.configReadLock.lock();
@@ -652,7 +669,7 @@ public class Rollbar {
       LOGGER.debug("Notifier disabled.");
       return;
     }
-    
+
     // Pre filter
     if (config.filter() != null && config.filter().preProcess(level, error.getThrowable(), custom,
         description)) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/json/JsonSerializerImpl.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/json/JsonSerializerImpl.java
@@ -59,6 +59,10 @@ public class JsonSerializerImpl implements JsonSerializer {
 
   @Override
   public String toJson(Payload payload) {
+    if (payload.json != null) {
+      return payload.json;
+    }
+
     StringBuilder builder = new StringBuilder();
     serializeValue(builder, payload, 0);
     return builder.toString();

--- a/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
@@ -411,6 +411,20 @@ public class RollbarTest {
   }
 
   @Test
+  public void shouldSendPayloadAsJson() {
+    Config config = withAccessToken("access_token")
+        .sender(sender)
+        .build();
+    Rollbar sut = new Rollbar(config);
+    String json = "{\"foo\":\"bar\"}";
+    Payload payload = new Payload(json);
+
+    sut.sendJsonPayload(json);
+
+    verify(sender).send(payload);
+  }
+
+  @Test
   public void shouldLogWithLogMethod() {
     Config config = withAccessToken(ACCESS_TOKEN)
         .timestamp(timestampProvider)

--- a/rollbar-java/src/test/java/com/rollbar/notifier/sender/json/JsonSerializerImplTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/sender/json/JsonSerializerImplTest.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import com.rollbar.api.payload.Payload;
 import com.rollbar.notifier.sender.result.Result;
 import org.junit.Test;
 
@@ -41,5 +42,16 @@ public class JsonSerializerImplTest {
     JsonSerializerImpl sut = new JsonSerializerImpl();
 
     assertThat(sut.resultFrom(SUCCESS_RESPONSE), is(result));
+  }
+
+  @Test
+  public void shouldSerializeJsonPayload() {
+    String json = "{\"foo\":\"bar\"}";
+
+    Payload payload = new Payload(json);
+
+    JsonSerializerImpl sut = new JsonSerializerImpl();
+
+    assertThat(sut.toJson(payload), is(json));
   }
 }


### PR DESCRIPTION
Enables the public interface for rollbar-android: `void sendJsonPayload(String json)`

This supports Cordova apps by allowing the Java env to handle sending Rollbar events for the JS env. This also means each of the SDKs (At least Java, iOS, and rollbar.js) should agree on the interface definition, and be able to support it.