### PR TITLE
Add enabled as an option to log4j2 appender

### DIFF
--- a/rollbar-log4j2/src/main/java/com/rollbar/log4j2/RollbarAppender.java
+++ b/rollbar-log4j2/src/main/java/com/rollbar/log4j2/RollbarAppender.java
@@ -64,6 +64,7 @@ public class RollbarAppender extends AbstractAppender {
    * @param endpoint the Rollbar endpoint to be used.
    * @param environment the environment.
    * @param language the language.
+   * @param enabled to enable or disable Rollbar.
    * @param configProviderClassName The class name of the config provider implementation to get
    *     the configuration.
    * @param name the name.
@@ -78,6 +79,7 @@ public class RollbarAppender extends AbstractAppender {
       @PluginAttribute("endpoint") final String endpoint,
       @PluginAttribute("environment") final String environment,
       @PluginAttribute("language") final String language,
+      @PluginAttribute("enabled") final boolean enabled,
       @PluginAttribute("configProviderClassName") final String configProviderClassName,
       @PluginAttribute("name") @Required final String name,
       @PluginElement("Layout") Layout<? extends Serializable> layout,
@@ -93,7 +95,8 @@ public class RollbarAppender extends AbstractAppender {
         .environment(environment)
         .endpoint(endpoint)
         .server(new ServerProvider())
-        .language(language);
+        .language(language)
+        .enabled(enabled);
 
     if (configProvider != null) {
       config = configProvider.provide(configBuilder);


### PR DESCRIPTION
I am looking for the ability to "enable/disable" rollbar from Log4j2's appender xml. Currently, it is always enabled by default. Looking to add the option of being able to turn off Rollbar.

```
        <Rollbar name="ROLLBAR">
            <accessToken>${rollbar.access.token}</accessToken>
            <environment>${environment}</environment>
            <enabled>${rollbar.enabled}</enabled>
        </Rollbar>
```