### PR TITLE
Fix pre filter error NullPointerException

### DIFF
--- a/rollbar-java/build.gradle
+++ b/rollbar-java/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
+
     integTestCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.11.0'
     integTestCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
 }

--- a/rollbar-java/build.gradle
+++ b/rollbar-java/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
-    compile 'com.google.code.findbugs:jsr305:3.0.2'
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     integTestCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.11.0'
     integTestCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -590,7 +590,6 @@ public class Rollbar {
 
     if (error != null) {
       rollbarThrowableWrapper = new RollbarThrowableWrapper(error);
-
     }
     this.log(rollbarThrowableWrapper, custom, description, level, isUncaught);
   }
@@ -671,8 +670,8 @@ public class Rollbar {
     }
 
     // Pre filter
-    if (config.filter() != null && config.filter().preProcess(level, error.getThrowable(), custom,
-        description)) {
+    if (config.filter() != null && config.filter().preProcess(level,
+            error != null ? error.getThrowable() : null, custom, description)) {
       LOGGER.debug("Pre-filtered error: {}", error);
       return;
     }
@@ -754,7 +753,6 @@ public class Rollbar {
     if (config.person() != null) {
       LOGGER.debug("Gathering person info.");
       dataBuilder.person(config.person().provide());
-
     }
 
     // Server

--- a/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/filter/Filter.java
@@ -3,6 +3,7 @@ package com.rollbar.notifier.filter;
 import com.rollbar.api.payload.data.Data;
 import com.rollbar.api.payload.data.Level;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Filter interface.
@@ -19,7 +20,8 @@ public interface Filter {
    * @param description the description.
    * @return true if filtered otherwise false.
    */
-  boolean preProcess(Level level, Throwable error, Map<String, Object> custom, String description);
+  boolean preProcess(Level level, @Nullable Throwable error, @Nullable Map<String,
+          Object> custom, @Nullable String description);
 
   /**
    * Post-filter hook to decide once the final payload is ready if it should be send to Rollbar.

--- a/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
@@ -325,6 +325,19 @@ public class RollbarTest {
   }
 
   @Test
+  public void shouldFilterPrefilterWithNullException(){
+    Level level = Level.INFO;
+    String description = "description";
+    Rollbar sut = new Rollbar(config, bodyFactory);
+
+    when(filter.preProcess(level, null, null, description)).thenReturn(false);
+
+    sut.log(null, null, description, level);
+
+    verify(filter).preProcess(level, null, null, description);
+  }
+
+  @Test
   public void shouldUseTheCorrectLevel() {
     Config config = withAccessToken(ACCESS_TOKEN)
         .timestamp(timestampProvider)


### PR DESCRIPTION
I tweaked out that some functionality like log info and warning doesn't work with the current version.

since 9c3e31db484cad5336ee984a877a62150bb1761c info, warnings and other logs without an error (null argument) will result in an internal exception in following line:

```
 private void process(ThrowableWrapper error, Map<String, Object> custom, String description,
      Level level, boolean isUncaught) {
    ...
    // Pre filter
    if (config.filter() != null && config.filter().preProcess(level, error.getThrowable(), custom,
        description)) {
      LOGGER.debug("Pre-filtered error: {}", error);
      return;
    }
    ...
}
```

Due error could be null the wrapper getThrowable() call will throw a null pointer exception.

**actual:**
rollbar.info("test") -> doesn't appears in rollbar dashboard

**expected:**
rollbar.info("test") -> does appear in rollbar dashboard


### Additional:
I also added nullable annotation to filter preProcess function due better kotlin usage. 

actual:
```
preProcess(
            level: Level,
            error: Throwable,
            custom: MutableMap<String, Any>,
            description: String
          )
```
This results in an illegal argument exception if java calls the interface with a null argument. 
E.g. preProcess(.., null, null, null) -> Exception

now with nullable annotation we have to implement like this:
```
object : Filter {
          override fun postProcess(data: Data?): Boolean {
            return false
          }

          override fun preProcess(
            level: Level,
            error: Throwable?,
            custom: MutableMap<String, Any>?,
            description: String?
          ): Boolean {
            return (error is UnknownHostException)
          }
}
```

