### PR TITLE
Allow configuring more options via logback xml

### DIFF
--- a/examples/rollbar-logback/src/main/resources/logback.xml
+++ b/examples/rollbar-logback/src/main/resources/logback.xml
@@ -9,6 +9,13 @@
 
     <appender name="ROLLBAR" class="com.rollbar.logback.RollbarAppender">
         <accessToken>[ACCESS_TOKEN]</accessToken>
+<!--    <environment>prod</environment>                  -->
+<!--    <language>kotlin</language>                      -->
+<!--    <staticContext>some context info</staticContext> -->
+<!--    <codeVersion>42</codeVersion>                    -->
+<!--    <enabled>true</enabled>                          -->
+<!--    <framework>spring-boot</framework>               -->
+<!--    <platform>OpenJDK 13</platform>                  -->
     </appender>
 
     <logger name="com.example.rollbar.logback" level="debug" additivity="false">

--- a/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
+++ b/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
@@ -50,8 +50,6 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
   private String framework;
 
   private String language;
-  
-  private boolean enabled;
 
   private String platform;
 

--- a/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
+++ b/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
@@ -12,6 +12,7 @@ import com.rollbar.notifier.config.Config;
 import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.config.ConfigProvider;
 import com.rollbar.notifier.config.ConfigProviderHelper;
+import com.rollbar.notifier.provider.Provider;
 import com.rollbar.notifier.provider.server.ServerProvider;
 import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
 import com.rollbar.notifier.wrapper.ThrowableWrapper;
@@ -38,11 +39,21 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
 
   private String accessToken;
 
+  private String codeVersion;
+
   private String endpoint;
+
+  private boolean enabled = true;
 
   private String environment;
 
+  private String framework;
+
   private String language;
+
+  private String platform;
+
+  private String staticContext;
 
   private String configProviderClassName;
 
@@ -70,7 +81,18 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
               .environment(this.environment)
               .endpoint(this.endpoint)
               .server(new ServerProvider())
-              .language(this.language);
+              .language(this.language)
+              .codeVersion(this.codeVersion)
+              .context(new Provider<String>() {
+                @Override
+                public String provide() {
+                  return RollbarAppender.this.staticContext;
+                }
+              })
+              .enabled(this.enabled)
+              .framework(this.framework)
+              .platform(this.platform)
+          ;
 
       if (configProvider != null) {
         config = configProvider.provide(configBuilder);
@@ -118,6 +140,14 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
     this.accessToken = accessToken;
   }
 
+  public void setCodeVersion(String codeVersion) {
+    this.codeVersion = codeVersion;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
   public void setEndpoint(String endpoint) {
     this.endpoint = endpoint;
   }
@@ -126,8 +156,20 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
     this.environment = environment;
   }
 
+  public void setFramework(String framework) {
+    this.framework = framework;
+  }
+
   public void setLanguage(String language) {
     this.language = language;
+  }
+
+  public void setPlatform(String platform) {
+    this.platform = platform;
+  }
+
+  public void setStaticContext(String staticContext) {
+    this.staticContext = staticContext;
   }
 
   public void setConfigProviderClassName(String configProviderClassName) {


### PR DESCRIPTION
We want to be able to configure rollbar more granularly just via the logback xml.

This is pretty powerful if combined with the possibility to use env vars in the logback.xml directly or even [spring properties in logbback-spring.xml](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#environment-properties), e.g. like:

```
    <springProperty scope="context" name="springApplicationName" source="spring.application.name" defaultValue="undefined-spring-application-name"/>

    <appender name="ROLLBAR" class="com.rollbar.logback.RollbarAppender">
        <accessToken>${ROLLBAR_ACCESS_TOKEN}</accessToken>
        <enabled>${ROLLBAR_ENABLED}</enabled>
        <environment>${KUBERNETES_POD_NAMESPACE}</environment>
        <context>${springApplicationName}</context>
    </appender>
```