### PR TITLE
Fix for a 403 error response from Nginx

### DIFF
--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/json/JsonSerializerImpl.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/json/JsonSerializerImpl.java
@@ -71,7 +71,12 @@ public class JsonSerializerImpl implements JsonSerializer {
   @Override
   public Result resultFrom(String response) {
     Matcher codeMatcher = CODE_PATTERN.matcher(response);
-    codeMatcher.find();
+    if (!codeMatcher.find()) {
+      return new Result.Builder()
+          .code(1)
+          .body(response)
+          .build();
+    }
     String codeStr = codeMatcher.group(1);
     int code;
     try {

--- a/rollbar-java/src/test/java/com/rollbar/notifier/sender/json/JsonSerializerImplTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/sender/json/JsonSerializerImplTest.java
@@ -12,10 +12,15 @@ public class JsonSerializerImplTest {
 
   static final String ERROR_MESSAGE = "This is the error message";
 
+  static final String UNEXPECTED_ERROR_MESSAGE = "Nobody expects the Spanish inquisition";
+
   static final String UUID = java.util.UUID.randomUUID().toString();
 
   static final String ERROR_RESPONSE = format("{\"err\": 1, {\"message\": \"%s\"}}",
       ERROR_MESSAGE);
+
+  static final String UNEXPECTED_ERROR_RESPONSE = format("<html><body>%s</body></html>",
+      UNEXPECTED_ERROR_MESSAGE);
 
   static final String SUCCESS_RESPONSE = format("{\"err\": 0, {\"uuid\": \"%s\"}}",
       UUID);
@@ -30,6 +35,18 @@ public class JsonSerializerImplTest {
     JsonSerializerImpl sut = new JsonSerializerImpl();
 
     assertThat(sut.resultFrom(ERROR_RESPONSE), is(result));
+  }
+
+  @Test
+  public void shouldDeserializeUnexpectedErrorResponse() {
+    Result result = new Result.Builder()
+        .code(1)
+        .body(UNEXPECTED_ERROR_RESPONSE)
+        .build();
+
+    JsonSerializerImpl sut = new JsonSerializerImpl();
+
+    assertThat(sut.resultFrom(UNEXPECTED_ERROR_RESPONSE), is(result));
   }
 
   @Test


### PR DESCRIPTION
It seems possible to access Rollbar's servers and get a 403 Forbidden response.
The code didn't handle this well at all since it always expects a json response
from the server.
This patch checks if the regex matcher succeeded and gracefully returns an error
response so you can actually determine what is going on.