### PR TITLE
Enable Android uncaught exception capture

### DIFF
--- a/gradle/android.quality.gradle
+++ b/gradle/android.quality.gradle
@@ -1,0 +1,47 @@
+apply plugin: "checkstyle"
+apply plugin: "findbugs"
+apply plugin: "jacoco"
+
+checkstyle {
+    toolVersion = "8.2"
+    sourceSets = [android.sourceSets.main]
+    configFile = file("$rootDir/tools/checkstyle/google_checks.xml")
+}
+
+findbugs {
+    sourceSets = [android.sourceSets.main]
+    includeFilter = file("$rootDir/tools/findbugs/findbugs.xml")
+}
+
+tasks.withType(Checkstyle) {
+    reports {
+        xml.enabled false
+        html.enabled true
+    }
+}
+
+tasks.withType(FindBugs) {
+    reports {
+        xml.enabled false
+        html.enabled true
+    }
+}
+
+android.testOptions {
+    unitTests.all {
+        jacoco {
+            append = false
+            destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
+            classDumpDir = file("$buildDir/jacoco/classpathdumps")
+        }
+    }
+}
+
+task jacocoTestReport(type: JacocoReport, dependsOn: 'test') {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.enabled true
+        html.destination file("${buildDir}/jacocoHtml")
+    }
+}

--- a/rollbar-android/build.gradle
+++ b/rollbar-android/build.gradle
@@ -16,6 +16,12 @@ repositories {
 
 apply plugin: 'com.android.library'
 
+subprojects {
+    if (it.name.contains('android')) {
+        apply from: "$rootDir/gradle/android.quality.gradle"
+    }
+}
+
 android {
     compileSdkVersion 27
     buildToolsVersion '27.0.3'
@@ -25,8 +31,22 @@ android {
         targetSdkVersion 27
         consumerProguardFiles 'proguard-rules.pro'
     }
+
+    buildTypes {
+        release {
+            testCoverageEnabled true
+        }
+        debug {
+            testCoverageEnabled true
+        }
+    }
 }
 
 dependencies {
     api project(':rollbar-java')
+
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.10.0'
+    androidTestImplementation "org.mockito:mockito-android:+"
 }

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -20,7 +20,6 @@ import com.rollbar.notifier.sender.BufferedSender;
 import com.rollbar.notifier.sender.SyncSender;
 import com.rollbar.notifier.sender.queue.DiskQueue;
 
-
 import java.io.File;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Collections;
@@ -297,6 +296,19 @@ public class Rollbar {
 
     if (registerExceptionHandler == true) {
       handleUncaughtErrors();
+    }
+  }
+
+  /**
+   * Get the current config.
+   *
+   * @return the config object.
+   */
+  public Config config() {
+    if (rollbar != null) {
+      return rollbar.config();
+    } else {
+      return null;
     }
   }
 

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -10,16 +10,19 @@ import android.os.Bundle;
 import android.util.Log;
 import com.rollbar.android.provider.ClientProvider;
 import com.rollbar.notifier.config.ConfigProvider;
+import com.rollbar.notifier.uncaughtexception.RollbarUncaughtExceptionHandler;
 import com.rollbar.android.provider.NotifierProvider;
 import com.rollbar.android.provider.PersonProvider;
 import com.rollbar.api.payload.data.Level;
 import com.rollbar.notifier.config.Config;
 import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.sender.BufferedSender;
+import com.rollbar.notifier.sender.SyncSender;
 import com.rollbar.notifier.sender.queue.DiskQueue;
 
 
 import java.io.File;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -257,13 +260,31 @@ public class Rollbar {
 
     File folder = new File(context.getCacheDir(), ITEM_DIR_NAME);
 
+    // DiskQueue allows uncaught exceptions to be handled for Android.
+    // The payload is saved before app exit and transmitted on next app start.
+    DiskQueue queue = new DiskQueue.Builder()
+        .queueFolder(folder)
+        .build();
+
+    SyncSender innerSender = new SyncSender.Builder()
+        .accessToken(accessToken)
+        .build();
+
+    BufferedSender sender = new BufferedSender.Builder()
+        .queue(queue)
+        .sender(innerSender)
+        .initialFlushDelay(TimeUnit.SECONDS.toMillis(DEFAULT_ITEM_SCHEDULE_STARTUP_DELAY))
+        .flushFreq(TimeUnit.SECONDS.toMillis(DEFAULT_ITEM_SCHEDULE_DELAY))
+        .build();
+
     ConfigBuilder defaultConfig = ConfigBuilder.withAccessToken(accessToken)
         .client(clientProvider)
         .platform(ANDROID)
         .framework(ANDROID)
         .notifier(new NotifierProvider(NOTIFIER_VERSION))
         .environment(environment == null ? DEFAULT_ENVIRONMENT : environment)
-        .handleUncaughtErrors(registerExceptionHandler);
+        .sender(sender)
+        .handleUncaughtErrors(false); // Use the global handler, not the default per thread one.
 
     Config config;
     if (configProvider != null) {
@@ -272,23 +293,11 @@ public class Rollbar {
       config = defaultConfig.build();
     }
 
-    if (config.sender() == null) {
-      DiskQueue queue = new DiskQueue.Builder()
-              .queueFolder(folder)
-              .build();
-
-      BufferedSender sender = new BufferedSender.Builder()
-              .queue(queue)
-              .initialFlushDelay(TimeUnit.SECONDS.toMillis(DEFAULT_ITEM_SCHEDULE_STARTUP_DELAY))
-              .flushFreq(TimeUnit.SECONDS.toMillis(DEFAULT_ITEM_SCHEDULE_DELAY))
-              .build();
-
-      config = ConfigBuilder.withConfig(config)
-              .sender(sender)
-              .build();
-    }
-
     this.rollbar = new com.rollbar.notifier.Rollbar(config);
+
+    if (registerExceptionHandler == true) {
+      handleUncaughtErrors();
+    }
   }
 
   /**
@@ -344,6 +353,15 @@ public class Rollbar {
             .build();
       }
     });
+  }
+
+  /**
+   * Handle all uncaught errors on all threads with the current notifier.
+   */
+  public void handleUncaughtErrors() {
+    UncaughtExceptionHandler uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+    Thread.currentThread().setDefaultUncaughtExceptionHandler(new RollbarUncaughtExceptionHandler(this.rollbar,
+        uncaughtExceptionHandler));
   }
 
   /**

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -19,6 +19,7 @@ import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.sender.BufferedSender;
 import com.rollbar.notifier.sender.SyncSender;
 import com.rollbar.notifier.sender.queue.DiskQueue;
+import com.rollbar.notifier.util.ObjectsUtils;
 
 import java.io.File;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -290,6 +291,10 @@ public class Rollbar {
       config = configProvider.provide(defaultConfig);
     } else {
       config = defaultConfig.build();
+    }
+
+    if (config.sender() != sender) {
+      ObjectsUtils.close(sender);
     }
 
     this.rollbar = new com.rollbar.notifier.Rollbar(config);

--- a/rollbar-android/src/test/java/com/rollbar/android/RollbarTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/RollbarTest.java
@@ -1,0 +1,231 @@
+package com.rollbar.android;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.PackageInfo;
+import android.os.Bundle;
+import android.test.mock.MockPackageManager;
+
+import com.rollbar.android.provider.NotifierProvider;
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.Data;
+import com.rollbar.api.payload.data.Level;
+import com.rollbar.api.payload.data.Notifier;
+import com.rollbar.notifier.config.Config;
+import com.rollbar.notifier.config.ConfigBuilder;
+import com.rollbar.notifier.config.ConfigProvider;
+import com.rollbar.notifier.filter.Filter;
+import com.rollbar.notifier.provider.Provider;
+import com.rollbar.notifier.sender.BufferedSender;
+import com.rollbar.notifier.sender.Sender;
+import com.rollbar.notifier.sender.SyncSender;
+import com.rollbar.notifier.sender.queue.DiskQueue;
+import com.rollbar.notifier.transformer.Transformer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+
+public class RollbarTest {
+  static final String ACCESS_TOKEN = "access_token";
+
+  static final String ENVIRONMENT = "environment";
+
+  static final String CODE_VERSION = "code_version";
+
+  static final String PLATFORM = "platform";
+
+  static final String LANGUAGE = "language";
+
+  static final String FRAMEWORK = "framework";
+
+  // Android mocks
+  @Mock
+  Context mockApplicationContext;
+
+  PackageManager mockPackageManager = new MockPackageManager() {
+    @Override
+    public PackageInfo getPackageInfo(String _name, int _flags) {
+        return mockPackageInfo;
+    }
+  };
+
+  @Mock
+  PackageInfo mockPackageInfo;
+
+  // Rollbar-java mocks
+  @Mock
+  Filter filter;
+
+  @Mock
+  Sender sender;
+
+  @Mock
+  Transformer transformer;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    when(mockApplicationContext.getPackageName()).thenReturn("package name");
+    when(mockApplicationContext.getPackageManager()).thenReturn(mockPackageManager);
+
+    mockPackageInfo.versionCode = 23;
+    mockPackageInfo.versionName = "version name";
+  }
+
+  @Test
+  public void shouldUseDefaultBufferedSenderAndDiskQueue() {
+    Config config;
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true);
+
+    config = sut.config();
+
+    assertThat(config.sender(), instanceOf(BufferedSender.class));
+    assertThat(((BufferedSender)config.sender()).queue(), instanceOf(DiskQueue.class));
+    assertThat(((BufferedSender)config.sender()).sender(), instanceOf(SyncSender.class));
+  }
+
+  @Test
+  public void shouldUseCustomSender() {
+    Config config;
+    final SyncSender syncSender = new SyncSender.Builder().build();
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true, false, new ConfigProvider() {
+      @Override
+      public Config provide(ConfigBuilder builder) {
+        return builder
+          .sender(syncSender)
+          .build();
+      }
+    });
+
+    config = sut.config();
+
+    assertThat(config.sender(), instanceOf(SyncSender.class));
+  }
+
+  @Test
+  public void shouldUseDefaultNotifier() {
+    Config config;
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true);
+
+    config = sut.config();
+
+    assertEquals(config.notifier().provide().getName(), "rollbar-android");
+  }
+
+  @Test
+  public void shouldUseCustomNotifier() {
+    Config config;
+    final String notifierVersion = "1.2.3";
+    final String notifierName = "custom-notifier";
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true, false, new ConfigProvider() {
+      @Override
+      public Config provide(ConfigBuilder builder) {
+        return builder
+          .notifier(new NotifierProvider(notifierVersion, notifierName))
+          .build();
+      }
+    });
+
+    config = sut.config();
+
+    assertEquals(config.notifier().provide().getVersion(), notifierVersion);
+    assertEquals(config.notifier().provide().getName(), notifierName);
+  }
+
+  @Test
+  public void shouldUseAndroidPackageInfo() {
+    Config config;
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true);
+
+    config = sut.config();
+
+    assertEquals(config.client().provide().getTopLevelData().get("code_version"), 23);
+    assertEquals(config.client().provide().getTopLevelData().get("name_version"), "version name");
+  }
+
+  @Test
+  public void shouldSendPayload() {
+    Throwable error = new RuntimeException("Something went wrong.");
+    Config config;
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true, false, new ConfigProvider() {
+      @Override
+      public Config provide(ConfigBuilder builder) {
+        return builder
+          .sender(sender)
+          .build();
+      }
+    });
+
+    config = sut.config();
+
+    sut.log(error);
+
+    verify(config.sender()).send(any(Payload.class));
+  }
+
+  @Test
+  public void shouldPostFilterWithoutSendingPayload() {
+    Level level = Level.ERROR;
+    Throwable error = new RuntimeException("Something went wrong.");
+    String description = "description";
+    Map<String, Object> custom = new HashMap<>();
+    Config config;
+
+    when(transformer.transform(any(Data.class))).thenReturn(mock(Data.class));
+    when(filter.preProcess(level, error, custom, description)).thenReturn(false);
+    when(filter.postProcess(any(Data.class))).thenReturn(true);
+
+    Rollbar sut = new Rollbar(mockApplicationContext, ACCESS_TOKEN, ENVIRONMENT, true, false, new ConfigProvider() {
+      @Override
+      public Config provide(ConfigBuilder builder) {
+        return builder
+          .transformer(transformer)
+          .filter(filter)
+          .sender(sender)
+          .build();
+      }
+    });
+
+    sut.log(error, custom, description, level);
+
+    config = sut.config();
+
+    verify(config.sender(), never()).send(any(Payload.class));
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -137,6 +137,15 @@ public class Rollbar {
     }
   }
 
+  /**
+   * Get the current config.
+   *
+   * @return the config.
+   */
+  public Config config() {
+    return config;
+  }
+
   private void processAppPackages(Config config) {
     for (String appPackage : config.appPackages()) {
       ThrowableCache.addAppPackage(appPackage);

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/BufferedSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/BufferedSender.java
@@ -55,6 +55,24 @@ public class BufferedSender implements Sender {
         builder.initialFlushDelay, builder.flushFreq, TimeUnit.MILLISECONDS);
   }
 
+  /**
+   * Get the queue.
+   *
+   * @return the queue object.
+   */
+  public Queue<Payload> queue() {
+    return queue;
+  }
+
+  /**
+   * Get the queue sender.
+   *
+   * @return the sender object.
+   */
+  public Sender sender() {
+    return sender;
+  }
+
   @Override
   public void send(Payload payload) {
     try {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/queue/DiskQueue.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/queue/DiskQueue.java
@@ -102,9 +102,15 @@ public class DiskQueue extends AbstractQueue<Payload> {
   }
 
   private Payload readFromFile(boolean removeFile) {
-    File eventFile = getFiles().get(0);
+    List<File> files = getFiles();
 
-    return read(eventFile, removeFile);
+    if (files.size() > 0) {
+      File eventFile = getFiles().get(0);
+
+      return read(eventFile, removeFile);
+    } else {
+      return null;
+    }
   }
 
   private List<File> getFiles() {

--- a/rollbar-java/src/test/java/com/rollbar/notifier/sender/queue/DiskQueueTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/sender/queue/DiskQueueTest.java
@@ -1,6 +1,7 @@
 package com.rollbar.notifier.sender.queue;
 
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -102,5 +103,15 @@ public class DiskQueueTest {
 
     assertThat(result, is(payload));
     assertThat(sut.size(), is(1));
+  }
+
+  @Test
+  public void shouldPollEmptyQueue() {
+    Payload payload = new Payload.Builder().build();
+
+    Payload result = sut.peek();
+
+    assertThat(result, is(nullValue()));
+    assertThat(sut.size(), is(0));
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-react-native/issues/104

This PR fixes several issues preventing uncaught exception capture from working in Android.

**Ensures the default sender uses `DiskQueue`**
The previous code _looks_ like it is setting up a `DiskQueue`, but the conditional `if (config.sender() == null)` executes _after_ `configProvider.provide(defaultConfig)` causes `build()` to be called on the config. At this point, `config.sender()` can never be null even if the supplied `configProvider` tries to set it to null. (Keep in mind this doesn't only affect rollbar-react-native, but all Android apps.) So the default `ConcurrentLinkedQueue` was being used. This won't work for Android uncaught exceptions, because after building the payload the sender will release the thread. The app will terminate, and the payload is lost. With `DiskQueue`, the payload is stored to disk and sent on the next app start.

This appears to be the pull request where this would have stopped working:
https://github.com/rollbar/rollbar-java/pull/168

**Closes the default sender when a custom sender is present**
https://github.com/rollbar/rollbar-java/pull/168 tried changing the initialization order so this step isn't needed, which led (in part) to the current issue.

**Fixes `IndexOutOfBoundsException` in `DiskQueue.poll()`**
There is a bug where calling `poll()` (or `peek()`) tries to reference the first element on the list while the list is empty. The uncaught `IndexOutOfBoundsException` keeps this queue from working. The exception will be hit anytime the queue of pending payloads is empty when the polling interval triggers.

**Uses `setDefaultUncaughtExceptionHandler`**
The existing `setUncaughtExceptionHandler` is per thread. Even if a public interface were to allow setting this for each thread, for popular frameworks like React Native that create their own threads, this would be impossible for the application to manage. This fix ensures exceptions on all threads will bubble up to the handler. The existing handler-per-thread behavior is preserved for non-android targets.

**Updates gradle config to run tests, lint and coverage for the android target.**

**Adds tests for the android target.**