### PR TITLE
Remove VERSION constant in rollbar-android and load from metadata

### DIFF
--- a/rollbar-android/build.gradle
+++ b/rollbar-android/build.gradle
@@ -30,6 +30,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 27
         consumerProguardFiles 'proguard-rules.pro'
+        manifestPlaceholders = [notifierVersion: VERSION_NAME]
     }
 
     buildTypes {

--- a/rollbar-android/src/main/AndroidManifest.xml
+++ b/rollbar-android/src/main/AndroidManifest.xml
@@ -4,5 +4,9 @@
           android:versionCode="1"
           android:versionName="1.0" >
 
+    <application>
+        <meta-data android:name="com.rollbar.android._notifier.version" android:value="${notifierVersion}" />
+    </application>
+
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -1,5 +1,7 @@
 package com.rollbar.android;
 
+import static com.rollbar.android.util.Constants.ROLLBAR_NAMESPACE;
+
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -28,7 +30,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class Rollbar {
-  private static final String NOTIFIER_VERSION = "1.7.2-SNAPSHOT";
+
   private static final String ITEM_DIR_NAME = "rollbar-items";
   private static final String ANDROID = "android";
   private static final String DEFAULT_ENVIRONMENT = "production";
@@ -37,7 +39,6 @@ public class Rollbar {
   private static final int DEFAULT_ITEM_SCHEDULE_DELAY = 15;
 
   public static final String TAG = "Rollbar";
-  private static final String ROLLBAR_NAMESPACE = "com.rollbar.android";
   private static final String MANIFEST_ACCESS_TOKEN = ROLLBAR_NAMESPACE + ".ACCESS_TOKEN";
 
   private com.rollbar.notifier.Rollbar rollbar;
@@ -281,7 +282,7 @@ public class Rollbar {
         .client(clientProvider)
         .platform(ANDROID)
         .framework(ANDROID)
-        .notifier(new NotifierProvider(NOTIFIER_VERSION))
+        .notifier(new NotifierProvider(context))
         .environment(environment == null ? DEFAULT_ENVIRONMENT : environment)
         .sender(sender)
         .handleUncaughtErrors(false); // Use the global handler, not the default per thread one.

--- a/rollbar-android/src/main/java/com/rollbar/android/provider/NotifierProvider.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/provider/NotifierProvider.java
@@ -1,5 +1,12 @@
 package com.rollbar.android.provider;
 
+import static com.rollbar.android.util.Constants.ROLLBAR_NAMESPACE;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
 import com.rollbar.api.payload.data.Notifier;
 import com.rollbar.notifier.provider.Provider;
 
@@ -8,11 +15,19 @@ import com.rollbar.notifier.provider.Provider;
  */
 public class NotifierProvider implements Provider<Notifier> {
 
+    private static final String VERSION_METADATA_NAME = ROLLBAR_NAMESPACE + "._notifier.version";
+
+    private static final String NAME = "rollbar-android";
+
     private final Notifier notifier;
+
+    public NotifierProvider(Context context) {
+        this(loadVersionFromContext(context));
+    }
 
     public NotifierProvider(String version) {
         this.notifier = new Notifier.Builder()
-                .name("rollbar-android")
+                .name(NAME)
                 .version(version)
                 .build();
     }
@@ -27,5 +42,15 @@ public class NotifierProvider implements Provider<Notifier> {
     @Override
     public Notifier provide() {
         return notifier;
+    }
+
+    private static String loadVersionFromContext(Context context) {
+        try {
+            ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            Bundle data = ai.metaData;
+            return data.getString(VERSION_METADATA_NAME);
+        } catch(PackageManager.NameNotFoundException e) {
+            return "unknown";
+        }
     }
 }

--- a/rollbar-android/src/main/java/com/rollbar/android/util/Constants.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/util/Constants.java
@@ -1,0 +1,9 @@
+package com.rollbar.android.util;
+
+public final class Constants {
+
+  public static final String ROLLBAR_NAMESPACE = "com.rollbar.android";
+
+  private Constants() {}
+
+}

--- a/rollbar-android/src/test/java/com/rollbar/android/RollbarTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/RollbarTest.java
@@ -67,16 +67,14 @@ public class RollbarTest {
 
   static final String FRAMEWORK = "framework";
 
+  static final String PACKAGE_NAME = "package_name";
+
   // Android mocks
   @Mock
   Context mockApplicationContext;
 
-  PackageManager mockPackageManager = new MockPackageManager() {
-    @Override
-    public PackageInfo getPackageInfo(String _name, int _flags) {
-        return mockPackageInfo;
-    }
-  };
+  @Mock
+  PackageManager mockPackageManager;
 
   @Mock
   PackageInfo mockPackageInfo;
@@ -91,15 +89,28 @@ public class RollbarTest {
   @Mock
   Transformer transformer;
 
+  @Mock
+  ApplicationInfo applicationInfo;
+
+  @Mock
+  Bundle bundle;
+
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    when(mockApplicationContext.getPackageName()).thenReturn("package name");
+    when(mockApplicationContext.getPackageName()).thenReturn(PACKAGE_NAME);
     when(mockApplicationContext.getPackageManager()).thenReturn(mockPackageManager);
+
+    when(mockPackageManager.getPackageInfo(anyString(), anyInt()))
+            .thenReturn(mockPackageInfo);
+    when(mockPackageManager.getApplicationInfo(eq(PACKAGE_NAME), eq(PackageManager.GET_META_DATA)))
+            .thenReturn(applicationInfo);
+    when(bundle.getString(eq("com.rollbar.android._notifier.version"))).thenReturn("1.7.0");
 
     mockPackageInfo.versionCode = 23;
     mockPackageInfo.versionName = "version name";
+    applicationInfo.metaData = this.bundle;
   }
 
   @Test

--- a/rollbar-android/src/test/java/com/rollbar/android/provider/NotifierProviderTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/provider/NotifierProviderTest.java
@@ -1,0 +1,64 @@
+package com.rollbar.android.provider;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import com.rollbar.api.payload.data.Notifier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+public class NotifierProviderTest {
+
+    private static final String NAME = "rollbar-android";
+
+    private static final String VERSION = "1.7.0";
+
+    private static final String PACKAGE_NAME = "package_name";
+
+    @Mock
+    Context context;
+
+    @Mock
+    PackageManager packageManager;
+
+    @Mock
+    ApplicationInfo applicationInfo;
+
+    @Mock
+    Bundle bundle;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(bundle.getString(eq("com.rollbar.android._notifier.version")))
+                .thenReturn(VERSION);
+        applicationInfo.metaData = this.bundle;
+
+        when(packageManager.getApplicationInfo(eq(PACKAGE_NAME), eq(PackageManager.GET_META_DATA)))
+                .thenReturn(applicationInfo);
+        when(context.getPackageManager()).thenReturn(packageManager);
+        when(context.getPackageName()).thenReturn(PACKAGE_NAME);
+    }
+
+    @Test
+    public void shouldUseVersionFromMetadata() {
+        NotifierProvider sut = new NotifierProvider(context);
+
+        Notifier notifier = sut.provide();
+
+        assertEquals(VERSION, notifier.getVersion());
+        assertEquals(NAME, notifier.getName());
+    }
+}


### PR DESCRIPTION
A new metadata property has been added with the name
`com.rollbar.android._notifier.version` in the library AndroidManifest
that will be injected from gradle using manifest place holders.

This will help to handle the versioning as now the value used 
is the `VERSION_NAME` coming from `gradle.properties`.