### PR TITLE
Add name, description and url pom properties missed after upgrade build system

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -56,6 +56,9 @@ afterEvaluate {
                                     fromResolutionResult()
                                 }
                             }
+                            name = POM_NAME
+                            description = POM_DESCRIPTION
+                            url = POM_URL
 
                             scm {
                                 url = POM_SCM_URL
@@ -137,6 +140,10 @@ afterEvaluate {
                                 }
                             }
 
+                            name = POM_NAME
+                            description = POM_DESCRIPTION
+                            url = POM_URL
+                            
                             scm {
                                 url = POM_SCM_URL
                                 connection = POM_SCM_CONNECTION


### PR DESCRIPTION
The automatic release process failed when closing the staging repository because of these missing properties.
