### PR TITLE
Add argumentArray key with arguments passed to log into rollbar-logback custom key

### DIFF
--- a/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
+++ b/rollbar-logback/src/main/java/com/rollbar/logback/RollbarAppender.java
@@ -35,6 +35,9 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
 
   private static final String CUSTOM_THREAD_NAME_KEY = "threadName";
 
+  private static final String CUSTOM_ARGUMENT_ARRAY_KEY = "argumentArray";
+
+
   private Rollbar rollbar;
 
   private String accessToken;
@@ -214,6 +217,8 @@ public class RollbarAppender extends AppenderBase<ILoggingEvent> {
 
     custom.put(CUSTOM_MDC_NAME_KEY, this.buildMdc(event));
     custom.put(CUSTOM_MAKER_NAME_KEY, this.getMarker(event));
+
+    custom.put(CUSTOM_ARGUMENT_ARRAY_KEY, event.getArgumentArray());
 
     Map<String, Object> rootCustom = new HashMap<>();
     rootCustom.put(CUSTOM_NAMESPACE_KEY, custom);


### PR DESCRIPTION
## Description of the change

Add new key `argumentArray` that will contain the arguments passed to the log sentence. That new key will be placed under `custom` object inside the `rollbar-logback` object.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
