### PR TITLE
Skip before_install decrypt if not rollbar repo or is PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,12 @@ android:
   - android-sdk-license-.+
   - ".+"
 before_install:
-- openssl aes-256-cbc -K $encrypted_d4596825e164_key -iv $encrypted_d4596825e164_iv
-  -in $ENCRYPTED_GPG_KEY_LOCATION -out $GPG_KEY_LOCATION -d
+- if [[ "$TRAVIS_REPO_SLUG" != "rollbar/rollbar-java" || "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    echo "Skipping descrypt.";
+  else
+    openssl aes-256-cbc -K $encrypted_d4596825e164_key -iv $encrypted_d4596825e164_iv -in $ENCRYPTED_GPG_KEY_LOCATION -out $GPG_KEY_LOCATION -d;
+  fi;
+
 install:
 - sdkmanager --list || true
 - sdkmanager --uninstall "system-images;android-15;default;armeabi-v7a"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ android:
   - ".+"
 before_install:
 - if [[ "$TRAVIS_REPO_SLUG" != "rollbar/rollbar-java" || "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-    echo "Skipping descrypt.";
+    echo "Skipping decrypt.";
   else
     openssl aes-256-cbc -K $encrypted_d4596825e164_key -iv $encrypted_d4596825e164_iv -in $ENCRYPTED_GPG_KEY_LOCATION -out $GPG_KEY_LOCATION -d;
   fi;


### PR DESCRIPTION
## Description of the change

Skip decrypt in `before_install` step if the build is not going to be released.

Some PR contributions failed because of this and it'd be nice to be able to see them running in travis.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
