### PR TITLE
Add all request parameters for post request method

### DIFF
--- a/rollbar-web/src/main/java/com/rollbar/web/provider/RequestProvider.java
+++ b/rollbar-web/src/main/java/com/rollbar/web/provider/RequestProvider.java
@@ -58,6 +58,7 @@ public class RequestProvider implements Provider<Request> {
           .method(method(req))
           .headers(headers(req))
           .get(getParams(req))
+          .post(postParams(req))
           .queryString(queryString(req))
           .userIp(userIp(req))
           .build();
@@ -140,19 +141,40 @@ public class RequestProvider implements Provider<Request> {
 
   private static Map<String, List<String>> getParams(HttpServletRequest request) {
     if ("GET".equalsIgnoreCase(request.getMethod())) {
-      Map<String, List<String>> params = new HashMap<>();
-
-      Map<String, String[]> paramNames = request.getParameterMap();
-      for (Entry<String, String[]> param : paramNames.entrySet()) {
-        if (param.getValue() != null && param.getValue().length > 0) {
-          params.put(param.getKey(), asList(param.getValue()));
-        }
-      }
-
-      return params;
+      return params(request);
     }
 
     return null;
+  }
+
+  private static Map<String, Object> postParams(HttpServletRequest request) {
+    if ("POST".equalsIgnoreCase(request.getMethod())) {
+      Map<String, List<String>> params = params(request);
+      Map<String, Object> postParams = new HashMap<>();
+      for (Entry<String, List<String>> entry : params.entrySet()) {
+        if (entry.getValue() != null && entry.getValue().size() == 1) {
+          postParams.put(entry.getKey(), entry.getValue().get(0));
+        } else {
+          postParams.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return postParams;
+    }
+
+    return null;
+  }
+
+  private static Map<String, List<String>> params(HttpServletRequest request) {
+    Map<String, List<String>> params = new HashMap<>();
+
+    Map<String, String[]> paramNames = request.getParameterMap();
+    for (Entry<String, String[]> param : paramNames.entrySet()) {
+      if (param.getValue() != null && param.getValue().length > 0) {
+        params.put(param.getKey(), asList(param.getValue()));
+      }
+    }
+
+    return params;
   }
 
   private static String queryString(HttpServletRequest request) {


### PR DESCRIPTION
## Description of the change

The `RequestProvider` was only adding request parameters when the request method is `GET`. After this change it should track those parameters for `POST` method as well.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
