### PR TITLE
Fix build badge to show Github action status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rollbar for Java and Android
 
-[![Build Status](https://travis-ci.org/rollbar/rollbar-java.svg?branch=master)](https://travis-ci.org/rollbar/rollbar-java)
+[![Build Status](https://github.com/rollbar/rollbar-java/workflows/rollbar-java%20CI/badge.svg?branch=master)](https://github.com/rollbar/rollbar-java/actions/workflows/ci.yml?query=branch%3Amaster)
 
 The current library has undergone a major overhaul between versions 0.5.4 and 1.0.0.
 We recommend upgrading from prior versions of `rollbar-java`, but that process may require some


### PR DESCRIPTION
## Description of the change

This fixed the CI badge in the README, which was still pointing to our Travis CI build. It now shows the status of the GH CI action for `master`, and links to it.

Related to #248 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
