### PR TITLE
Update release.sh to actually call gradle to do the release

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -43,10 +43,10 @@ else
 
   if [[ ${BASH_REMATCH[5]} == 'SNAPSHOT' ]]; then
     echo "Doing SNAPSHOT release..."
-    echo ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype
+    ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype
   else
     echo "Doing release..."
-    echo ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype closeAndReleaseRepository
+    ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype closeAndReleaseRepository
   fi
   echo "Release done!"
 fi


### PR DESCRIPTION
## Description of the change

In #249 I left an 'echo' command in front of the gradle invocations that should publish the maven artifacts, so nothing has been published since then. 🤦 

This fixes that. 

It has been re-tested using a local nexus container.  

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
