### PR TITLE
Add comment to explain how HTTPS connection is established in SyncSender

### DIFF
--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
@@ -59,6 +59,7 @@ public class SyncSender extends AbstractSender {
   }
 
   private HttpURLConnection getConnection() throws IOException {
+    // By default, this will use the HTTPS Rollbar API URL defined in DEFAULT_API_ENDPOINT.
     HttpURLConnection connection = (HttpURLConnection) url.openConnection(this.proxy);
 
     if (accessToken != null && !"".equals(accessToken)) {


### PR DESCRIPTION
## Description of the change

There was a misunderstanding recently where a user thought connections to the Rollbar API were done via HTTP instead of HTTPS, due to our use of the `HttpUrlConnection` class. This adds a small comment explaining rollbar-java connects to the Rollbar HTTPS API URL by default. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- []  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
