### PR TITLE
Don't require an access token in log4j appender when configuration class is provided

### DIFF
--- a/rollbar-log4j2/src/main/java/com/rollbar/log4j2/RollbarAppender.java
+++ b/rollbar-log4j2/src/main/java/com/rollbar/log4j2/RollbarAppender.java
@@ -1,6 +1,7 @@
 package com.rollbar.log4j2;
 
 import static com.rollbar.notifier.config.ConfigBuilder.withAccessToken;
+import static org.apache.logging.log4j.core.util.Assert.isEmpty;
 
 import com.rollbar.api.payload.data.Level;
 import com.rollbar.notifier.Rollbar;
@@ -22,6 +23,7 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.Node;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
@@ -76,7 +78,7 @@ public class RollbarAppender extends AbstractAppender {
    */
   @PluginFactory
   public static RollbarAppender createAppender(
-      @PluginAttribute("accessToken") @Required final String accessToken,
+      @PluginAttribute("accessToken") final String accessToken,
       @PluginAttribute("codeVersion") final String codeVersion,
       @PluginAttribute("endpoint") final String endpoint,
       @PluginAttribute("environment") final String environment,
@@ -88,6 +90,11 @@ public class RollbarAppender extends AbstractAppender {
       @PluginElement("Filter") Filter filter,
       @PluginAttribute("ignoreExceptions") final String ignore
   ) {
+    // No @Required(a || b) in log4j, so we check this manually
+    if (isEmpty(accessToken) && isEmpty(configProviderClassName)) {
+      throw new ConfigurationException("Either accessToken or configProviderClassName must be "
+              + "provided");
+    }
 
     ConfigProvider configProvider = ConfigProviderHelper
         .getConfigProvider(configProviderClassName);

--- a/rollbar-log4j2/src/test/java/com/rollbar/log4j2/RollbarAppenderIntegrationTest.java
+++ b/rollbar-log4j2/src/test/java/com/rollbar/log4j2/RollbarAppenderIntegrationTest.java
@@ -1,0 +1,136 @@
+package com.rollbar.log4j2;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.notifier.config.Config;
+import com.rollbar.notifier.config.ConfigBuilder;
+import com.rollbar.notifier.config.ConfigProvider;
+import com.rollbar.notifier.sender.Sender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.impl.Log4jContextFactory;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class RollbarAppenderIntegrationTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private Sender sender;
+
+    @After
+    public void tearDown() {
+        TestConfigProvider.SENDER.set(null);
+    }
+
+    @Test
+    public void whenConfigProviderIsProvidedIsShouldNotRequireATokenParameter() throws IOException {
+        TestConfigProvider.SENDER.set(sender);
+        String configClass = TestConfigProvider.class.getName();
+
+        String appenderConfig = "<configProviderClassName>" + configClass + "</configProviderClassName>\n";
+
+        LoggerContext context = getLoggerContext(appenderConfig);
+
+        context.getRootLogger().error("Test error");
+
+        assertTrue("Timed out shutting down the logger context", context.stop(1, TimeUnit.MINUTES));
+        
+        ArgumentCaptor<Payload> actualPayload = ArgumentCaptor.forClass(Payload.class);
+        verify(sender, times(1)).send(actualPayload.capture());
+
+        assertThat(actualPayload.getValue().getAccessToken(), equalTo(TestConfigProvider.TEST_TOKEN));
+    }
+
+    @Test
+    public void whenTokenIsProvidedIsShouldNotRequireAConfigProvider() throws IOException {
+        String token = "1234";
+
+        String appenderConfig = "<accessToken>" + token + "</accessToken>\n";
+
+        LoggerContext context = getLoggerContext(appenderConfig);
+
+        // The sender has been built using the default config so we can't easily mock it. We will just check that
+        // the appender has been created.
+        assertThat(context.getRootLogger().getAppenders().keySet(), contains("ROLLBAR"));
+
+        assertTrue("Timed out shutting down the logger context", context.stop(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    public void whenTokenAndConfigProviderAreMissingItShouldFailToInitializeAppender() throws IOException {
+        String token = "1234";
+
+        String appenderConfig = "<environment>development</environment>\n";
+
+        LoggerContext context = getLoggerContext(appenderConfig);
+
+        // log4j will swallow all appender exceptions so we can't check them directly.
+        assertThat(context.getRootLogger().getAppenders().keySet(), not(contains("ROLLBAR")));
+
+        assertTrue("Timed out shutting down the logger context", context.stop(1, TimeUnit.MINUTES));
+    }
+
+    private LoggerContext getLoggerContext(String appenderConfig) throws IOException {
+        /*
+        There is a slightly more unit-level test we could do here with something like this:
+
+        PluginManager plugins = new PluginManager("core");
+        plugins.collectPlugins(Collections.singletonList("com.rollbar"));
+        PluginType<?> plugin = plugins.getPluginType("Rollbar");
+        DefaultConfiguration pluginConfig = new DefaultConfiguration();
+
+        (setup config)
+
+        RollbarAppender appender = (RollbarAppender) new PluginBuilder(plugin)...
+
+        ...but it depends on log4j plugin classes that, while public, are probably not as stable as the standard
+        logging context initialization classes. So better do a full on integration test. Execution time is fast enough,
+        ~50ms per test
+         */
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<Configuration status=\"INFO\">\n" +
+                "  <Appenders>\n" +
+                "    <Rollbar name=\"ROLLBAR\">" + appenderConfig + "</Rollbar>\n" +
+                "  </Appenders>\n" +
+                "  <Loggers>\n" +
+                "    <Root level=\"debug\">\n" +
+                "      <AppenderRef ref=\"ROLLBAR\" />\n" +
+                "    </Root>\n" +
+                "  </Loggers>\n" +
+                "</Configuration>";
+
+        ConfigurationSource config = new ConfigurationSource(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+        return new Log4jContextFactory().getContext(this.getClass().getName(),
+                RollbarAppender.class.getClassLoader(), null, false, config);
+    }
+
+    public static class TestConfigProvider implements ConfigProvider {
+        public static final ThreadLocal<Sender> SENDER = new ThreadLocal<>();
+        public static final String TEST_TOKEN = "CONFIG_PROVIDER_TOKEN";
+
+        @Override
+        public Config provide(ConfigBuilder builder) {
+            return builder.accessToken(TEST_TOKEN).enabled(true).sender(SENDER.get()).build();
+        }
+    }
+}


### PR DESCRIPTION
## Description of the change

The configuration class can provide the access token, so we don't need it to be required as an appender parameter when a configuration class is configured. 

This change will validate that either a configuration class or an access token is provided (both are also allowed), and will fail to initialise the appender *only* when neither is present. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
