### PR TITLE
Add revapi binary and source backwards compatibility check to build.

### DIFF
--- a/.github/fetch_to_tag.sh
+++ b/.github/fetch_to_tag.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Github actions will do shallow clones which is great for performance, but some of our
+# tasks require a history going back to the most recent tag, so this script achieves
+# that, without pulling the full history
+
+function fetch_to_tag() {
+    n="$1"
+    if [ "$n" == "" ]; then
+        n=2
+    fi
+    
+    echo "Fetching commits with depth ${n}"
+
+    rev=$(git rev-list -n 1 HEAD)
+
+    git fetch origin --depth "$n" "$rev"
+
+    if ! git describe --tags --abbrev=0 HEAD^ 1>/dev/null 2>&1; then
+        fetch_to_tag "$(expr "$n" \* 2)"
+    fi
+}
+
+git fetch origin 'refs/tags/*:refs/tags/*'
+
+fetch_to_tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         java: [8, 11]
     steps:
       - uses: actions/checkout@v2
+        
+      - name: Fetch git tags
+        run: ./.github/fetch_to_tag.sh
+          
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
       # and we store its JAVA_HOME

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.4.0"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2"
         classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.2.4"
+        classpath "com.palantir.gradle.revapi:gradle-revapi:1.4.4"
     }
 }
 
@@ -37,6 +38,8 @@ subprojects { project ->
         apply from: "$rootDir/gradle/release.gradle"
 
         apply from: "$rootDir/gradle/quality.gradle"
+        
+        apply from: "$rootDir/gradle/compatibility.gradle"
 
         repositories {
             mavenCentral()

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'com.palantir.revapi'
+
+revapi {
+    oldGroup = GROUP
+    // By default, revapi will check against the version matching the most recent
+    // git tag, so we don't need to specify anything else here.
+    // If an artifact with the given version doesn't exist on maven, it will skip
+    // the check, so new projects won't cause any failures, and after the first
+    // version of a project is published it will start checking it.
+}


### PR DESCRIPTION
## Description of the change

This adds a revapi (https://github.com/revapi/revapi) binary and compile level compatibility check to the gradle build.

Revapi seems to be the most straight forward and maintained Java binary compatibility checker available. Based on my tests it has very good (if not complete) coverage of the Java spec's "Binary Compatiblity" section (https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html)

The gradle plugin will automatically check the build against the most recent git tag, which works very well in our case since all published versions have tags. It will skip checks when a published artifact does not exist for a given project, so it won't break when new projects are added, but will automatically start checking them as soon as we have published an initial version.

Breaking changes can be added to an exclusion list, so it won't prevent us from making changes intentionally, but hopefully it will catch accidental compatibility breakages. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
