### PR TITLE
Use generated class instead of jar manifest to populate notifier vers…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ atlassian-ide-plugin.xml
 
 # Secrets
 .github/secring.gpg
+
+# Local gradle properties
+local.properties

--- a/rollbar-java/build.gradle
+++ b/rollbar-java/build.gradle
@@ -12,12 +12,66 @@ buildscript {
 apply plugin: "nebula.integtest"
 
 dependencies {
-    api project(':rollbar-api')
+  api project(':rollbar-api')
 
-    api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+  api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+  compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-    integTestImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.0'
-    integTestImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
+  integTestImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.0'
+  integTestImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
+}
+
+/**
+ * This task will create a version property that is statically referenced when populating the
+ * `notifier` section of the payload. It helps when users shade and / or relocate the
+ * `rollbar-java` classes, since in those cases we no longer have access to our jar manifest.
+ * The task creates a Java class instead of a text resource, since dynamically loaded resources
+ * are not as reliable under relocation as a strongly typed bytecode reference to a compiled class.
+ */
+task createVersionClass() {
+  ext.set("OUTPUT_DIR", [buildDir.getAbsolutePath(), 'src', 'generated', 'main'].join(File.separator))
+
+  outputs.dir(ext.OUTPUT_DIR)
+
+  doLast {
+    def pkg = ["com", "rollbar", "notifier", "provider", "notifier"];
+
+    def pkgName = pkg.join(".");
+    def pkgPath = "${ext.OUTPUT_DIR}${File.separator}" +
+            (['src', 'generated'] + pkg).join(File.separator)
+    def escapedVersion = VERSION_NAME.replace('"', '\\"');
+
+    def classText = """package ${pkgName};
+
+class VersionHelperResources {
+  static String getVersion() {
+    return "${escapedVersion}";
+  }
+}
+"""
+
+    new File(pkgPath).mkdirs()
+    def classFile = new File(pkgPath, 'VersionHelperResources.java').newWriter()
+    try {
+      classFile << classText
+    } finally {
+      classFile.close()
+    }
+  }
+}
+
+sourceSets {
+  main {
+    java.srcDirs += project.tasks.createVersionClass.ext.OUTPUT_DIR
+  }
+}
+
+project.tasks.compileJava.dependsOn(project.tasks.createVersionClass);
+project.tasks.checkstyleMain.dependsOn(project.tasks.createVersionClass);
+
+test {
+  // This helps us test the VersionHelper class since there's no jar manifest available when
+  // running tests. 
+  systemProperty 'ROLLBAR_IMPLEMENTATION_VERSION', VERSION_NAME
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/provider/notifier/VersionHelper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/provider/notifier/VersionHelper.java
@@ -2,9 +2,26 @@ package com.rollbar.notifier.provider.notifier;
 
 class VersionHelper {
 
+  /**
+   * Get the current version of the `rollbar-java` notifier.
+   *
+   * <p>
+   * When shading `rollbar-java` into a different jar, the version from our jar's manifest is lost,
+   * and only the user's version is kept. Our classes become part of the user's jar, and
+   * `VersionHelper.class.getPackage().getImplementationVersion()` returns the user's jar's
+   * implementation version.
+   * There several shading tools out there with different levels of support for resources, manifest
+   * merging, etc... The only thing they all reliably support when they relocate a class is updating
+   * class and method references present in bytecode form.
+   * So rather than putting our version in a resource and hoping that we can still dynamically
+   * reference it after relocation, we just create the VersionHelperResources class in Gradle, which
+   * we know will still work after relocation since we're referencing it statically.
+   * Obviously we keep the version in `rollbar-java`'s jar manifest, but we don't rely on it here.
+   * </p>
+   *
+   * @return The version of the `rollbar-java` notifier currently loaded.
+   */
   public String version() {
-    String version = VersionHelper.class.getPackage().getImplementationVersion();
-
-    return version != null ? version : "unknown";
+    return com.rollbar.notifier.provider.notifier.VersionHelperResources.getVersion();
   }
 }

--- a/rollbar-java/src/test/java/com/rollbar/notifier/provider/notifier/VersionHelperTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/provider/notifier/VersionHelperTest.java
@@ -1,16 +1,27 @@
 package com.rollbar.notifier.provider.notifier;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
 public class VersionHelperTest {
+  @Test
+  public void shouldReturnVersion() {
+    VersionHelper helper = new VersionHelper();
+    // It will fail when we upgrade to 2.x, but it's stable enough. Better than nothing when running
+    // from an IDE, without the version property that we set in Gradle.
+    assertThat(helper.version(), startsWith("1."));
+  }
 
   @Test
-  public void shouldReturnNullIfNotAvailable() {
-    VersionHelper helper = new VersionHelper();
+  public void versionReturnedShouldMatchManifestVersion() {
+    // We set this in Gradle since there's no jar manifest available when running tests.
+    String expectedVersion = System.getProperty("ROLLBAR_IMPLEMENTATION_VERSION");
+    assumeThat(expectedVersion, not(isEmptyOrNullString()));
 
-    assertThat(helper.version(), is("unknown"));
+    VersionHelper helper = new VersionHelper();
+    assertThat(helper.version(), equalTo(expectedVersion));
   }
 }


### PR DESCRIPTION
This PR updates the method we use to find the notifier version, to use a generated Java class instead of the jar's manifest attributes. 

This fixes the notifier version attribute when users shade rollbar-java, since until now we could end up reporting the version of the user's application as the notifier version instead of our own, due to the fact that our classes had been merged into the user's jar, and only one manifest resource (the user's) remained. 

The approach we take now is to generate a static class at build time, with a single method returning the version. This removes the need for any dynamic resource loading, which could fail under relocation since the references are strings. 

## Description of the change

> Description here
## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[ch85159]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
