### PR TITLE
Add option to truncate payloads before sending them to Rollbar.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -13,3 +13,15 @@ acceptedBreaks:
       old: "field com.rollbar.notifier.config.ConfigBuilder.defaultThrowableLevel"
       justification: "Removing protected fields, deriving from ConfigBuilder should\
         \ be done by other SDK classes only"
+  "1.7.9":
+    com.rollbar:rollbar-java:
+    - code: "java.method.addedToInterface"
+      new: "method boolean com.rollbar.notifier.config.CommonConfig::truncateLargePayloads()"
+      justification: "This is a binary compatible change, which could only break custom\
+        \ implementations of our config interfaces, but those interfaces are not meant\
+        \ to be implemented by users"
+    - code: "java.method.addedToInterface"
+      new: "method com.rollbar.notifier.sender.json.JsonSerializer com.rollbar.notifier.config.CommonConfig::jsonSerializer()"
+      justification: "This is a binary compatible change, which could only break custom\
+        \ implementations of our config interfaces, but those interfaces are not meant\
+        \ to be implemented by users"

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/Payload.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/Payload.java
@@ -1,7 +1,10 @@
 package com.rollbar.api.payload;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInObject;
+
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.payload.data.Data;
+import com.rollbar.api.truncation.StringTruncatable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -9,7 +12,7 @@ import java.util.Map;
  * Represents the payload to send to Rollbar. A successfully constructed Payload matches Rollbar's
  * spec, and should be successful when serialized and POSTed to the correct endpoint.
  */
-public class Payload implements JsonSerializable {
+public class Payload implements JsonSerializable, StringTruncatable<Payload> {
 
   private static final long serialVersionUID = 3054041443735286159L;
 
@@ -100,6 +103,17 @@ public class Payload implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Payload truncateStrings(int maxLength) {
+    if (this.data == null) {
+      return this;
+    }
+
+    return new Payload.Builder(this)
+        .data(truncateStringsInObject(data, maxLength))
+        .build();
   }
 
   public int getSendAttemptCount() {

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Data.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Data.java
@@ -1,14 +1,20 @@
 package com.rollbar.api.payload.data;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInMap;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInObject;
+
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.payload.data.body.Body;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Represents the actual data being posted to Rollbar.
  */
-public class Data implements JsonSerializable {
+public class Data implements JsonSerializable, StringTruncatable<Data> {
 
   private static final long serialVersionUID = 4996853277611613397L;
 
@@ -304,6 +310,28 @@ public class Data implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Data truncateStrings(int maxLength) {
+    return new Builder(this)
+        .environment(truncateString(environment, maxLength))
+        .body(truncateStringsInObject(body, maxLength))
+        .codeVersion(truncateString(codeVersion, maxLength))
+        .platform(truncateString(platform, maxLength))
+        .language(truncateString(language, maxLength))
+        .framework(truncateString(framework, maxLength))
+        .context(truncateString(context, maxLength))
+        .request(truncateStringsInObject(request, maxLength))
+        .person(truncateStringsInObject(person, maxLength))
+        .server(truncateStringsInObject(server, maxLength))
+        .client(truncateStringsInObject(client, maxLength))
+        .custom(truncateStringsInMap(custom, maxLength))
+        .fingerprint(truncateString(fingerprint, maxLength))
+        .title(truncateString(title, maxLength))
+        .uuid(truncateString(uuid, maxLength))
+        .notifier(truncateStringsInObject(notifier, maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Notifier.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Notifier.java
@@ -1,13 +1,17 @@
 package com.rollbar.api.payload.data;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Information about this notifier, or one based off of this.
  */
-public class Notifier implements JsonSerializable {
+public class Notifier implements JsonSerializable, StringTruncatable<Notifier> {
 
   private static final long serialVersionUID = -2605608164795462842L;
 
@@ -80,6 +84,19 @@ public class Notifier implements JsonSerializable {
     }
 
     return values;
+  }
+
+
+  @Override
+  public Notifier truncateStrings(int maxLength) {
+    if (name == null && version == null) {
+      return this;
+    }
+
+    return new Notifier.Builder(this)
+        .name(truncateString(name, maxLength))
+        .version(truncateString(version, maxLength))
+        .build();
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Person.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Person.java
@@ -1,15 +1,19 @@
 package com.rollbar.api.payload.data;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInMap;
 import static java.util.Collections.unmodifiableMap;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Represents the user affected by an error.
  */
-public class Person implements JsonSerializable {
+public class Person implements JsonSerializable, StringTruncatable<Person> {
 
   private static final long serialVersionUID = -1589474813294741393L;
 
@@ -79,6 +83,16 @@ public class Person implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Person truncateStrings(int maxLength) {
+    return new Builder(this)
+        .metadata(truncateStringsInMap(metadata, maxLength))
+        .id(truncateString(id, maxLength))
+        .username(truncateString(username, maxLength))
+        .email(truncateString(email, maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Request.java
@@ -1,8 +1,14 @@
 package com.rollbar.api.payload.data;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInMap;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInStringListMap;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInStringMap;
 import static java.util.Collections.unmodifiableMap;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -10,7 +16,7 @@ import java.util.Map;
 /**
  * Represents the HTTP request that triggered the error.
  */
-public class Request implements JsonSerializable {
+public class Request implements JsonSerializable, StringTruncatable<Request> {
 
   private static final long serialVersionUID = 3552594955980476301L;
 
@@ -164,6 +170,22 @@ public class Request implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Request truncateStrings(int maxLength) {
+    return new Builder(this)
+        .metadata(truncateStringsInMap(metadata, maxLength))
+        .url(truncateString(url, maxLength))
+        .method(truncateString(method, maxLength))
+        .headers(truncateStringsInStringMap(headers, maxLength))
+        .params(truncateStringsInStringMap(params, maxLength))
+        .get(truncateStringsInStringListMap(get, maxLength))
+        .queryString(truncateString(queryString, maxLength))
+        .post(truncateStringsInMap(post, maxLength))
+        .body(truncateString(body, maxLength))
+        .userIp(truncateString(userIp, maxLength))
+        .build();
   }
 
   private Map<String, Object> processGetParams(Map<String, List<String>> map) {

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Server.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Server.java
@@ -1,15 +1,20 @@
 package com.rollbar.api.payload.data;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInMap;
+import static java.util.Collections.max;
 import static java.util.Collections.unmodifiableMap;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Represents the server object sent to Rollbar.
  */
-public class Server implements JsonSerializable {
+public class Server implements JsonSerializable, StringTruncatable<Server> {
 
   private static final long serialVersionUID = -9135498029274932688L;
 
@@ -93,6 +98,18 @@ public class Server implements JsonSerializable {
     }
 
     return values;
+  }
+
+
+  @Override
+  public Server truncateStrings(int maxLength) {
+    return new Builder(this)
+        .metadata(truncateStringsInMap(metadata, maxLength))
+        .host(truncateString(host, maxLength))
+        .root(truncateString(root, maxLength))
+        .branch(truncateString(branch, maxLength))
+        .codeVersion(truncateString(codeVersion, maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -1,12 +1,14 @@
 package com.rollbar.api.payload.data.body;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 
 /**
  * A container for the actual error(s), message, or crash report that caused this error.
  */
-public class Body implements JsonSerializable {
+public class Body implements JsonSerializable, StringTruncatable<Body> {
 
   private static final long serialVersionUID = -2783273957046705016L;
 
@@ -33,6 +35,17 @@ public class Body implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Body truncateStrings(int maxSize) {
+    if (bodyContent != null) {
+      return new Body.Builder(this)
+          .bodyContent(bodyContent.truncateStrings(maxSize))
+          .build();
+    } else {
+      return this;
+    }
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/BodyContent.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/BodyContent.java
@@ -1,9 +1,11 @@
 package com.rollbar.api.payload.data.body;
 
+import com.rollbar.api.truncation.StringTruncatable;
+
 /**
  * A marker interface for the contents of the rollbar body.
  */
-public interface BodyContent {
+public interface BodyContent extends StringTruncatable<BodyContent> {
 
   /**
    * The key name of the body content.

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/CodeContext.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/CodeContext.java
@@ -1,8 +1,11 @@
 package com.rollbar.api.payload.data.body;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInList;
 import static java.util.Collections.unmodifiableList;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +15,7 @@ import java.util.Map;
  * Represents the context around the code where the error occurred (lines before, 'pre', and after,
  * 'post').
  */
-public class CodeContext implements JsonSerializable {
+public class CodeContext implements JsonSerializable, StringTruncatable<CodeContext> {
 
   private static final long serialVersionUID = 1271972843983198079L;
 
@@ -53,6 +56,14 @@ public class CodeContext implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public CodeContext truncateStrings(int maxLength) {
+    return new CodeContext.Builder(this)
+        .pre(truncateStringsInList(pre, maxLength))
+        .post(truncateStringsInList(post, maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/CrashReport.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/CrashReport.java
@@ -1,6 +1,8 @@
 package com.rollbar.api.payload.data.body;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.TruncationHelper;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,6 +42,13 @@ public class CrashReport implements BodyContent, JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public CrashReport truncateStrings(int maxLength) {
+    return new CrashReport.Builder(this)
+        .raw(TruncationHelper.truncateString(getRaw(), maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/ExceptionInfo.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/ExceptionInfo.java
@@ -1,6 +1,10 @@
 package com.rollbar.api.payload.data.body;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,7 +12,7 @@ import java.util.Map;
  * Represents *non-stacktrace* information about an exception, like class, description, and
  * message.
  */
-public class ExceptionInfo implements JsonSerializable {
+public class ExceptionInfo implements JsonSerializable, StringTruncatable<ExceptionInfo> {
 
   private static final long serialVersionUID = -2271411217988417830L;
 
@@ -63,6 +67,19 @@ public class ExceptionInfo implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public ExceptionInfo truncateStrings(int maxLength) {
+    if (className == null && message == null && description == null) {
+      return this;
+    }
+
+    return new Builder(this)
+        .className(truncateString(className, maxLength))
+        .message(truncateString(message, maxLength))
+        .description(truncateString(description, maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Frame.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Frame.java
@@ -1,9 +1,15 @@
 package com.rollbar.api.payload.data.body;
 
+import static com.rollbar.api.truncation.TruncationHelper.truncateString;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInMap;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInObject;
+import static com.rollbar.api.truncation.TruncationHelper.truncateStringsInObjectList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +18,7 @@ import java.util.Map;
 /**
  * Represents a single frame from a stack trace.
  */
-public class Frame implements JsonSerializable {
+public class Frame implements JsonSerializable, StringTruncatable<Frame> {
 
   private static final long serialVersionUID = 8146147181798580520L;
 
@@ -167,6 +173,20 @@ public class Frame implements JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Frame truncateStrings(int maxLength) {
+    return new Frame.Builder(this)
+        .filename(truncateString(filename, maxLength))
+        .method(truncateString(method, maxLength))
+        .code(truncateString(code, maxLength))
+        .className(truncateString(className, maxLength))
+        .context(truncateStringsInObject(context, maxLength))
+        .args(truncateStringsInObjectList(args, maxLength))
+        .keywordArgs(truncateStringsInMap(keywordArgs, maxLength))
+        .locals(truncateStringsInMap(locals, maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Message.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Message.java
@@ -3,6 +3,8 @@ package com.rollbar.api.payload.data.body;
 import static java.util.Collections.unmodifiableMap;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.TruncationHelper;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,6 +53,18 @@ public class Message implements BodyContent, JsonSerializable {
     }
     message.put("body", this.body);
     return message;
+  }
+
+  @Override
+  public Message truncateStrings(int maxLength) {
+    if (this.metadata == null && this.body == null) {
+      return this;
+    }
+
+    return new Message.Builder(this)
+        .metadata(TruncationHelper.truncateStringsInMap(this.metadata, maxLength))
+        .body(TruncationHelper.truncateString(getBody(), maxLength))
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Trace.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Trace.java
@@ -3,6 +3,8 @@ package com.rollbar.api.payload.data.body;
 import static java.util.Collections.unmodifiableList;
 
 import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,6 +59,31 @@ public class Trace implements BodyContent, JsonSerializable {
     }
 
     return values;
+  }
+
+  @Override
+  public Trace truncateStrings(int maxLength) {
+    if ((frames == null || frames.isEmpty()) && exception == null) {
+      return this;
+    }
+
+    ArrayList<Frame> truncatedFrames = null;
+    if (frames != null) {
+      truncatedFrames = new ArrayList<>();
+      for (Frame f : frames) {
+        truncatedFrames.add(f.truncateStrings(maxLength));
+      }
+    }
+
+    ExceptionInfo truncatedException = null;
+    if (exception != null) {
+      truncatedException = exception.truncateStrings(maxLength);
+    }
+
+    return new Trace.Builder(this)
+        .frames(truncatedFrames)
+        .exception(truncatedException)
+        .build();
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/TraceChain.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/TraceChain.java
@@ -39,6 +39,25 @@ public class TraceChain implements BodyContent, JsonSerializable {
   }
 
   @Override
+  public TraceChain truncateStrings(int maxLength) {
+    if (traces == null || traces.isEmpty()) {
+      return this;
+    }
+
+    // Type erasure + BodyContent inheritance means a generic helper would end up seeing a
+    // BodyContent return type instead of Trace, forcing a cast. We do everything here instead,
+    // where we can take advantage of the overriden method returning Trace.
+    List<Trace> truncatedTraces = new ArrayList<>();
+    for (Trace trace : traces) {
+      truncatedTraces.add(trace.truncateStrings(maxLength));
+    }
+
+    return new Builder(this)
+        .traces(truncatedTraces)
+        .build();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/rollbar-api/src/main/java/com/rollbar/api/truncation/StringTruncatable.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/truncation/StringTruncatable.java
@@ -1,0 +1,8 @@
+package com.rollbar.api.truncation;
+
+import com.rollbar.api.annotations.Unstable;
+
+@Unstable
+public interface StringTruncatable<T> {
+  T truncateStrings(int maxLength);
+}

--- a/rollbar-api/src/main/java/com/rollbar/api/truncation/TruncationHelper.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/truncation/TruncationHelper.java
@@ -1,0 +1,162 @@
+package com.rollbar.api.truncation;
+
+import com.rollbar.api.annotations.Unstable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Unstable
+public class TruncationHelper {
+  /**
+   * Truncates all the strings in the list to the specified maximum length.
+   * @param values The strings to be truncated.
+   * @param maxLength Maximum length of each string.
+   * @return A list containing the truncated strings.
+   */
+  public static List<String> truncateStringsInList(List<String> values, int maxLength) {
+    if (values == null) {
+      return null;
+    }
+
+    List<String> result = new ArrayList<>(values.size());
+    for (String value : values) {
+      result.add(truncateString(value, maxLength));
+    }
+
+    return result;
+  }
+
+  /**
+   * Truncates any strings in the list to the specified maximum length.
+   * @param values The list of objects which might contain strings to be truncated.
+   * @param maxLength Maximum length of each string.
+   * @return A list with a copy of the values, where any string value has been truncated.
+   */
+  public static List<Object> truncateStringsInObjectList(List<Object> values, int maxLength) {
+    if (values == null) {
+      return null;
+    }
+
+    List<Object> result = new ArrayList<>(values.size());
+    for (Object value : values) {
+      if (value instanceof String) {
+        result.add(truncateString((String) value, maxLength));
+      } else {
+        result.add(value);
+      }
+
+    }
+
+    return result;
+  }
+
+  /**
+   * Truncates the strings in the object implementing StringTruncatable.
+   * @param value The value whose strings must be truncated.
+   * @param maxLength The maximum length of the strings.
+   * @param <T> The type of the value.
+   * @return A T instance with its strings truncated.
+   */
+  public static <T extends StringTruncatable<T>> T truncateStringsInObject(T value, int maxLength) {
+    if (value == null) {
+      return null;
+    }
+    return value.truncateStrings(maxLength);
+  }
+
+  /**
+   * Truncates the string to the specified maximum length.
+   * @param original The string to be truncated.
+   * @param maxLength The maximum length.
+   * @return The string truncated to the specified maximum length.
+   */
+  public static String truncateString(String original, int maxLength) {
+    if (original == null || original.length() <= maxLength) {
+      return original;
+    }
+
+    return original.substring(0, maxLength);
+  }
+
+  /**
+   * Truncates strings found in a map of lists of strings.
+   * @param values The map of lists of strings.
+   * @param maxLength The maximum length of each string.
+   * @return A map with all the strings truncated to the specified maximum length.
+   */
+  public static Map<String, List<String>> truncateStringsInStringListMap(
+      Map<String, List<String>> values, int maxLength) {
+    if (values == null || values.isEmpty()) {
+      return values;
+    }
+
+    Map<String, List<String>> result = new HashMap<>();
+    for (Map.Entry<String, List<String>> entry : values.entrySet()) {
+      result.put(entry.getKey(), truncateStringsInList(entry.getValue(), maxLength));
+    }
+
+    return result;
+  }
+
+  /**
+   * Truncates strings found in a map of strings.
+   * @param values The map of strings.
+   * @param maxLength The maximum length of each string.
+   * @return A map with all the strings truncated to the specified maximum length.
+   */
+  public static Map<String, String> truncateStringsInStringMap(Map<String, String> values,
+                                                               int maxLength) {
+    if (values == null || values.isEmpty()) {
+      return values;
+    }
+
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, String> entry : values.entrySet()) {
+      result.put(entry.getKey(), truncateString(entry.getValue(), maxLength));
+    }
+
+    return result;
+  }
+
+  /**
+   * Truncates strings found in a map of maps of objects.
+   * @param values The map of maps.
+   * @param maxLength The maximum length of each string.
+   * @return A map with all the strings truncated to the specified maximum length.
+   */
+  public static Map<String, Map<String, Object>> truncateStringsInNestedMap(
+      Map<String, Map<String, Object>> values, int maxLength) {
+    Map<String, Map<String, Object>> result = new HashMap<>();
+
+    for (Map.Entry<String, Map<String, Object>> entry : values.entrySet()) {
+      result.put(entry.getKey(), truncateStringsInMap(entry.getValue(), maxLength));
+    }
+
+    return result;
+  }
+
+  /**
+   * Truncates strings found in a map of objects.
+   * @param values The map of objects.
+   * @param maxLength The maximum length of each string.
+   * @return A map with all the strings truncated to the specified maximum length.
+   */
+  public static Map<String, Object> truncateStringsInMap(Map<String, Object> values,
+                                                         int maxLength) {
+    if (values == null || values.isEmpty()) {
+      return values;
+    }
+
+    Map<String, Object> result = new HashMap<>();
+    for (Map.Entry<String, Object> entry : values.entrySet()) {
+      Object value = entry.getValue();
+      if (value instanceof String) {
+        value = truncateString((String)value, maxLength);
+      }
+      result.put(entry.getKey(), value);
+    }
+    return result;
+  }
+}

--- a/rollbar-java/src/integTest/java/com/rollbar/notifier/RollbarITest.java
+++ b/rollbar-java/src/integTest/java/com/rollbar/notifier/RollbarITest.java
@@ -49,7 +49,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import jdk.jfr.StackTrace;
 import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.server.Request;

--- a/rollbar-java/src/integTest/java/com/rollbar/notifier/RollbarITest.java
+++ b/rollbar-java/src/integTest/java/com/rollbar/notifier/RollbarITest.java
@@ -10,26 +10,27 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.rollbar.notifier.config.ConfigBuilder.withAccessToken;
 import static java.lang.String.format;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.rollbar.api.payload.Payload;
 import com.rollbar.api.payload.data.Data;
 import com.rollbar.api.payload.data.Level;
-import com.rollbar.api.payload.data.body.Body;
-import com.rollbar.api.payload.data.body.Message;
+import com.rollbar.api.payload.data.body.*;
 import com.rollbar.notifier.config.Config;
 import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.provider.Provider;
 import com.rollbar.notifier.sender.Sender;
 import com.rollbar.notifier.sender.SyncSender;
+import com.rollbar.notifier.sender.json.JsonTestHelper;
 import com.rollbar.notifier.sender.listener.SenderListener;
 import com.rollbar.notifier.sender.result.Response;
+import com.rollbar.notifier.truncation.PayloadTruncator;
 import com.rollbar.notifier.util.ConstantTimeProvider;
 import com.rollbar.notifier.util.RollbarResponse;
 import com.rollbar.notifier.util.SenderAssertions;
@@ -41,13 +42,14 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Proxy.Type;
-import java.util.Locale;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import jdk.jfr.StackTrace;
 import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.server.Request;
@@ -309,6 +311,51 @@ public class RollbarITest {
     listener.assertCalled();
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  public void ifPayloadIsTooLargeItShouldBeTruncated() {
+    final String uuid = UUID.randomUUID().toString();
+
+    Config config = configBuilder
+        .truncateLargePayloads(true)
+        .build();
+
+    stubFor(post(urlEqualTo("/api/1/item/"))
+        .withHeader("Accept", equalTo("application/json"))
+        .withHeader("Accept-Charset", equalTo("UTF-8"))
+        .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+        .withHeader("x-rollbar-access-token", equalTo(ACCESS_TOKEN))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(gson.toJson(RollbarResponse.success(uuid)))));
+
+    SenderAssertions.SuccessAssertion listener =
+        SenderAssertions.assertResponseSuccess(uuid);
+
+    sender.addListener(listener);
+
+    Rollbar rollbar = new Rollbar(config);
+
+    rollbar.error(new TooLargeException(5000));
+
+    listener.assertCalled();
+
+    Payload payload = listener.getLatestPayload();
+    assertThat(payload, notNullValue());
+
+    String payloadJsonString = config.jsonSerializer().toJson(payload);
+    Map<String, Object> map = new Gson().fromJson(payloadJsonString, Map.class);
+    List<Map<String, Object>> frames =
+        getValue(map, "data", "body", "trace", "frames");
+
+    // By default 10 head and 10 tail frames are kept
+    assertThat(frames, hasSize(20));
+
+    assertThat(PayloadTruncator.sizeInBytes(payloadJsonString),
+        lessThanOrEqualTo(512 * 1024));
+  }
+
   protected Sender buildSender(String url, String accessToken, Proxy proxy) {
     SyncSender.Builder builder = new SyncSender.Builder()
         .url(url);
@@ -433,5 +480,51 @@ public class RollbarITest {
                        HttpServletResponse response) {
       counter.incrementAndGet();
     }
+  }
+
+  private static class TooLargeException extends Throwable {
+    private StackTraceElement[] frames;
+
+    public TooLargeException(int frameCount) {
+      this.frames = new StackTraceElement[frameCount];
+      for (int j = 0; j < frames.length; ++j) {
+        this.frames[j] = new StackTraceElement("loader1", "module",
+            repeat("filename", 100), j + 1);
+      }
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+      return this.frames;
+    }
+  }
+
+  private static String repeat(String value, int count) {
+    StringBuilder sb = new StringBuilder();
+    for (int j = 0; j < count; ++j) {
+      sb.append(value);
+    }
+
+    return sb.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getValue(Map<String, Object> source, String attribute,
+                                String... attributes) {
+    Object value = source.get(attribute);
+
+    if (attributes.length == 0) {
+      return (T) value;
+    }
+
+    if (value == null) {
+      throw new NullPointerException("No value with key " + attribute);
+    }
+
+    Map<String, Object> asMap = (Map<String, Object>)value;
+    String[] newAttributes = new String[attributes.length - 1];
+    System.arraycopy(attributes, 1, newAttributes, 0, newAttributes.length);
+
+    return getValue(asMap, attributes[0], newAttributes);
   }
 }

--- a/rollbar-java/src/integTest/java/com/rollbar/notifier/util/SenderAssertions.java
+++ b/rollbar-java/src/integTest/java/com/rollbar/notifier/util/SenderAssertions.java
@@ -98,6 +98,7 @@ public final class SenderAssertions {
     private volatile boolean called;
     private final Thread testThread;
     private Runnable deferredAsserts;
+    private Payload latestPayload;
 
     private AssertListener(Thread testThread) {
       this.testThread = testThread;
@@ -114,6 +115,7 @@ public final class SenderAssertions {
     @Override
     public void onResponse(Payload payload, Response response) {
       this.called = true;
+      this.latestPayload = payload;
       if (Thread.currentThread().equals(testThread)) {
         onResponseAssert(payload, response);
       } else {
@@ -128,6 +130,7 @@ public final class SenderAssertions {
     @Override
     public void onError(Payload payload, Exception error) {
       this.called = true;
+      this.latestPayload = payload;
       if (Thread.currentThread().equals(testThread)) {
         onErrorAssert(payload, error);
       } else {
@@ -137,6 +140,10 @@ public final class SenderAssertions {
           onErrorAssert(payload, error);
         };
       }
+    }
+
+    public Payload getLatestPayload() {
+      return latestPayload;
     }
 
     public abstract void onResponseAssert(Payload payload, Response response);

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/CommonConfig.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/CommonConfig.java
@@ -9,6 +9,7 @@ import com.rollbar.api.payload.data.Server;
 import com.rollbar.notifier.filter.Filter;
 import com.rollbar.notifier.fingerprint.FingerprintGenerator;
 import com.rollbar.notifier.provider.Provider;
+import com.rollbar.notifier.sender.json.JsonSerializer;
 import com.rollbar.notifier.transformer.Transformer;
 import com.rollbar.notifier.uuid.UuidGenerator;
 import java.util.List;
@@ -152,6 +153,13 @@ public interface CommonConfig {
   UuidGenerator uuidGenerator();
 
   /**
+   * The serializer to convert a payload to JSON.
+   *
+   * @return The {@link JsonSerializer instance}.
+   */
+  JsonSerializer jsonSerializer();
+
+  /**
    * Get the list of packages considered to be in your app.
    *
    * @return the list of packages.
@@ -192,4 +200,14 @@ public interface CommonConfig {
    * @return the level.
    */
   Level defaultThrowableLevel();
+
+
+  /**
+   * <p>
+   * If set to true, the notifier will attempt to truncate payloads that are larger than the
+   * maximum size Rollbar allows. Default: false.
+   * </p>
+   * @return true to truncate payloads otherwise false.
+   */
+  boolean truncateLargePayloads();
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java
@@ -2,6 +2,8 @@ package com.rollbar.notifier.config;
 
 import com.rollbar.notifier.Rollbar;
 import com.rollbar.notifier.sender.Sender;
+import com.rollbar.notifier.sender.json.JsonSerializer;
+
 import java.net.Proxy;
 
 /**

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/json/JsonSerializerImpl.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/json/JsonSerializerImpl.java
@@ -63,8 +63,17 @@ public class JsonSerializerImpl implements JsonSerializer {
       return payload.json;
     }
 
+    return toJson(payload.asJson());
+  }
+
+  /**
+   * Converts the map to a JSON string.
+   * @param map The map to be converted to a JSON string.
+   * @return A JSON string that represents the map.
+   */
+  public String toJson(Map<String, Object> map) {
     StringBuilder builder = new StringBuilder();
-    serializeValue(builder, payload, 0);
+    serializeObject(map, builder, 0);
     return builder.toString();
   }
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/FramesStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/FramesStrategy.java
@@ -1,0 +1,114 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.Data;
+import com.rollbar.api.payload.data.body.Body;
+import com.rollbar.api.payload.data.body.BodyContent;
+import com.rollbar.api.payload.data.body.Frame;
+import com.rollbar.api.payload.data.body.Trace;
+import com.rollbar.api.payload.data.body.TraceChain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class FramesStrategy implements TruncationStrategy {
+  private final int headFrameCount;
+  private final int tailFrameCount;
+
+  public FramesStrategy() {
+    this(10, 10);
+  }
+
+  public FramesStrategy(int headFrameCount, int tailFrameCount) {
+    this.headFrameCount = headFrameCount;
+    this.tailFrameCount = tailFrameCount;
+  }
+
+  @Override
+  public TruncationResult<Payload> truncate(Payload payload) {
+    if (payload == null || payload.getData() == null || payload.getData().getBody() == null) {
+      return TruncationResult.none();
+    }
+
+    Body body = payload.getData().getBody();
+    BodyContent content = body.getContents();
+
+    if (content instanceof Trace) {
+      return mapResult(payload, truncateTrace((Trace) content));
+    } else if (content instanceof TraceChain) {
+      return mapResult(payload, truncateTraceChain((TraceChain) content));
+    }
+
+    return TruncationResult.none();
+  }
+
+  private TruncationResult<TraceChain> truncateTraceChain(TraceChain chain) {
+    boolean truncated = false;
+
+    ArrayList<Trace> updated = new ArrayList<>();
+    for (Trace trace: chain.getTraces()) {
+      TruncationResult<Trace> result = truncateTrace(trace);
+      if (result.wasTruncated) {
+        updated.add(result.value);
+      } else {
+        updated.add(trace);
+      }
+
+      truncated |= result.wasTruncated;
+    }
+
+    if (truncated) {
+      return TruncationResult.truncated(new TraceChain.Builder(chain).traces(updated).build());
+    } else {
+      return TruncationResult.none();
+    }
+  }
+
+  private TruncationResult<Trace> truncateTrace(Trace trace) {
+    List<Frame> frames = trace.getFrames();
+
+    if (frames.size() <= totalFramesToKeep()) {
+      return TruncationResult.none();
+    }
+
+    List<Frame> updatedFrames = truncateFrames(frames);
+
+    return TruncationResult.truncated(
+        new Trace.Builder(trace).frames(updatedFrames).build()
+    );
+  }
+
+  int totalFramesToKeep() {
+    return headFrameCount + tailFrameCount;
+  }
+
+  List<Frame> truncateFrames(List<Frame> frames) {
+    ArrayList<Frame> updatedFrames = new ArrayList<>();
+
+    for (int j = 0; j < headFrameCount; ++j) {
+      updatedFrames.add(frames.get(j));
+    }
+
+    int size = frames.size();
+    for (int j = size - tailFrameCount; j < size; ++j) {
+      updatedFrames.add(frames.get(j));
+    }
+    return updatedFrames;
+  }
+
+  private <T extends BodyContent> TruncationResult<Payload> mapResult(Payload payload,
+                                                                      TruncationResult<T> result) {
+    if (!result.wasTruncated) {
+      return TruncationResult.none();
+    }
+
+    Payload newPayload = new Payload.Builder(payload).data(
+        new Data.Builder(payload.getData()).body(
+            new Body.Builder(payload.getData().getBody())
+                .bodyContent(result.value).build()
+        ).build()
+    ).build();
+
+    return TruncationResult.truncated(newPayload);
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/MinBodyStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/MinBodyStrategy.java
@@ -1,0 +1,138 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.Data;
+import com.rollbar.api.payload.data.body.Body;
+import com.rollbar.api.payload.data.body.BodyContent;
+import com.rollbar.api.payload.data.body.ExceptionInfo;
+import com.rollbar.api.payload.data.body.Frame;
+import com.rollbar.api.payload.data.body.Trace;
+import com.rollbar.api.payload.data.body.TraceChain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class MinBodyStrategy implements TruncationStrategy {
+  private static final FramesStrategy FRAMES_STRATEGY = new FramesStrategy(1, 1);
+  private static final int MAX_EXCEPTION_MSG_LENGTH = 255;
+
+  @Override
+  public TruncationResult<Payload> truncate(Payload payload) {
+    if (payload == null || payload.getData() == null || payload.getData().getBody() == null) {
+      return TruncationResult.none();
+    }
+
+    BodyContent content = payload.getData().getBody().getContents();
+
+    if (content instanceof TraceChain) {
+      return tryTruncateChain(payload, (TraceChain) content);
+    } else if (content instanceof Trace) {
+      return tryTruncateTrace(payload, (Trace) content);
+    }
+
+    return TruncationResult.none();
+  }
+
+  private TruncationResult<Payload> tryTruncateTrace(Payload payload, Trace trace) {
+    TruncationResult<Trace> traceResult = truncateTrace(trace);
+    if (traceResult.wasTruncated) {
+      return payloadWithContent(payload, traceResult.value);
+    }
+    return TruncationResult.none();
+  }
+
+  private TruncationResult<Payload> tryTruncateChain(Payload payload, TraceChain chain) {
+    boolean truncated = false;
+
+    List<Trace> newTraces = new ArrayList<>();
+    for (Trace trace : chain.getTraces()) {
+      TruncationResult<Trace> traceResult = truncateTrace(trace);
+      if (traceResult.wasTruncated) {
+        newTraces.add(traceResult.value);
+        truncated = true;
+      } else {
+        newTraces.add(trace);
+      }
+    }
+
+    if (truncated) {
+      return payloadWithContent(payload,
+          new TraceChain.Builder(chain)
+              .traces(newTraces)
+              .build()
+      );
+    } else {
+      return TruncationResult.none();
+    }
+  }
+
+  private TruncationResult<Payload> payloadWithContent(Payload payload, BodyContent newContent) {
+    Body body = new Body.Builder(payload.getData().getBody())
+        .bodyContent(newContent)
+        .build();
+
+    Data data = new Data.Builder(payload.getData())
+        .body(body)
+        .build();
+
+    Payload newPayload = new Payload.Builder(payload)
+        .data(data)
+        .build();
+
+    return TruncationResult.truncated(newPayload);
+  }
+
+  private TruncationResult<Trace> truncateTrace(Trace trace) {
+    boolean truncated = false;
+    List<Frame> frames = trace.getFrames();
+    if (trace.getFrames().size() > FRAMES_STRATEGY.totalFramesToKeep()) {
+      frames = FRAMES_STRATEGY.truncateFrames(trace.getFrames());
+      truncated = true;
+    }
+
+    ExceptionInfo exception = trace.getException();
+    TruncationResult<ExceptionInfo> result = truncateException(exception);
+    if (result.wasTruncated) {
+      exception = result.value;
+      truncated = true;
+    }
+
+    if (truncated) {
+      Trace newTrace = new Trace.Builder(trace)
+          .frames(frames)
+          .exception(exception)
+          .build();
+      return TruncationResult.truncated(newTrace);
+    } else {
+      return TruncationResult.none();
+    }
+  }
+
+  private TruncationResult<ExceptionInfo> truncateException(ExceptionInfo exception) {
+    if (exception != null) {
+      boolean truncated = false;
+
+      String description = exception.getDescription();
+      if (description != null) {
+        description = null;
+        truncated = true;
+      }
+
+      String message = exception.getMessage();
+      if (message != null && message.length() > MAX_EXCEPTION_MSG_LENGTH) {
+        message = message.substring(0, MAX_EXCEPTION_MSG_LENGTH);
+        truncated = true;
+      }
+
+      if (truncated) {
+        exception = new ExceptionInfo.Builder(exception)
+            .description(description)
+            .message(message)
+            .build();
+        return TruncationResult.truncated(exception);
+      }
+    }
+
+    return TruncationResult.none();
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/PayloadTruncator.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/PayloadTruncator.java
@@ -1,0 +1,79 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.notifier.sender.json.JsonSerializer;
+import com.rollbar.notifier.util.ObjectsUtils;
+
+import java.nio.charset.Charset;
+
+public class PayloadTruncator {
+  // We send data to Rollbar in UTF-8, so we use this to calculate payload size
+  private static final Charset TRANSPORT_CHARSET = Charset.forName("UTF-8");
+
+  private static final TruncationStrategy[] STRATEGIES = {
+      new FramesStrategy(),
+      new StringsStrategy(1024),
+      new StringsStrategy(512),
+      new StringsStrategy(256),
+      new MinBodyStrategy(),
+  };
+
+  private final JsonSerializer serializer;
+
+  public PayloadTruncator(JsonSerializer serializer) {
+    ObjectsUtils.requireNonNull(serializer, "serializer cannot be null");
+    this.serializer = serializer;
+  }
+
+  /**
+   * <p>
+   * Attempts to truncate the payload so that its JSON representation, encoded as UTF-8, has size
+   * equal or less than the specified maximum size size.
+   * </p>
+   * @param payload The payload to be truncated.
+   * @param maxSizeInBytes The maximum size, in bytes, for the payload.
+   * @return The truncated payload.
+   */
+  public PayloadTruncationResult truncate(Payload payload, int maxSizeInBytes) {
+    String json = serializer.toJson(payload);
+    int currentSize = sizeInBytes(json);
+
+    for (int j = 0; currentSize > maxSizeInBytes && j < STRATEGIES.length; ++j) {
+      TruncationStrategy.TruncationResult<Payload> result = STRATEGIES[j].truncate(payload);
+      if (result.wasTruncated) {
+        payload = result.value;
+        json = serializer.toJson(payload);
+        currentSize = sizeInBytes(json);
+      }
+    }
+
+    // Skip serialization from now on and use a pre-serialized payload.
+    return new PayloadTruncationResult(new Payload(json), currentSize);
+  }
+
+  /**
+   * The size of the JSON string, as UTF-8 bytes.
+   * @param payloadJsonString The string to measure.
+   * @return The size, in UTF-8 encoded bytes, of the string.
+   */
+  public static int sizeInBytes(String payloadJsonString) {
+    if (payloadJsonString == null) {
+      return 0;
+    }
+    return payloadJsonString.getBytes(TRANSPORT_CHARSET).length;
+  }
+
+  public static final class PayloadTruncationResult {
+    private final Payload payload;
+    public final int finalSize;
+
+    PayloadTruncationResult(Payload payload, int finalSize) {
+      this.payload = payload;
+      this.finalSize = finalSize;
+    }
+
+    public Payload getPayload() {
+      return payload;
+    }
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/StringsStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/StringsStrategy.java
@@ -1,0 +1,20 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+
+class StringsStrategy implements TruncationStrategy {
+  private final int stringLength;
+
+  public StringsStrategy(int stringLength) {
+    this.stringLength = stringLength;
+  }
+
+  @Override
+  public TruncationResult<Payload> truncate(Payload payload) {
+    if (payload == null || payload.getData() == null) {
+      return TruncationResult.none();
+    }
+
+    return TruncationResult.truncated(payload.truncateStrings(stringLength));
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/TruncationStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/TruncationStrategy.java
@@ -1,0 +1,37 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+
+interface TruncationStrategy {
+  /**
+   * Truncate the payload.
+   * @param payload The payload to be truncated.
+   * @return A TruncationResult instance.
+   */
+  TruncationResult<Payload> truncate(Payload payload);
+
+  class TruncationResult<T> {
+    /**
+     * True if the value was truncated.
+     */
+    public final boolean wasTruncated;
+    /**
+     * If the value was truncated, this will hold the truncated value. Otherwise this will
+     * be null.
+     */
+    public final T value;
+
+    private TruncationResult(boolean wasTruncated, T result) {
+      this.wasTruncated = wasTruncated;
+      this.value = result;
+    }
+
+    public static <T> TruncationResult<T> none() {
+      return new TruncationResult<>(false, null);
+    }
+
+    public static <T> TruncationResult<T> truncated(T result) {
+      return new TruncationResult<>(true, result);
+    }
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/PayloadTestHelper.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/PayloadTestHelper.java
@@ -1,0 +1,20 @@
+package com.rollbar.notifier;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.body.BodyContent;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class PayloadTestHelper {
+  @SuppressWarnings("unchecked")
+  public static <T extends BodyContent> T getBodyContentAs(Class<T> clazz, Payload payload) {
+    assertThat("Payload should not be null", payload, not(nullValue()));
+    assertThat("Data should not be null", payload.getData(), not(nullValue()));
+    assertThat("Body should not be null", payload.getData().getBody(), not(nullValue()));
+
+    BodyContent content = payload.getData().getBody().getContents();
+    assertThat(content, instanceOf(clazz));
+    return (T)content;
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/FramesStrategyTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/FramesStrategyTest.java
@@ -1,0 +1,229 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.body.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.rollbar.notifier.PayloadTestHelper.getBodyContentAs;
+import static com.rollbar.notifier.truncation.TruncationMatchers.differsOnlyBy;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public abstract class FramesStrategyTest {
+  private static final int HEAD_FRAMES = 10;
+  private static final int TAIL_FRAMES = 10;
+  private static final int MAX_FRAMES = HEAD_FRAMES + TAIL_FRAMES;
+
+  protected TestPayloadBuilder builder;
+
+  @Before
+  public void setUp() {
+     this.builder = new TestPayloadBuilder();
+  }
+
+  public static class TraceChainTest extends FramesStrategyTest {
+    @Test
+    public void whenFrameCountIsLessThan20ItShouldNotTruncate() {
+      testNoTruncation(MAX_FRAMES - 1, MAX_FRAMES / 2);
+    }
+
+    @Test
+    public void whenFrameCountIs20ItShouldNotTruncate() {
+      testNoTruncation(MAX_FRAMES, MAX_FRAMES, MAX_FRAMES, MAX_FRAMES);
+    }
+
+    @Test
+    public void whenTruncating21FramesStartChainItShouldLeave10HeadAnd10TailFrames() {
+      testChainTruncation(
+          MAX_FRAMES + 1,
+          MAX_FRAMES,
+          MAX_FRAMES - 1
+      );
+    }
+
+    @Test
+    public void whenTruncating21FramesMidChainItShouldLeave10HeadAnd10TailFrames() {
+      testChainTruncation(
+          MAX_FRAMES - 1,
+          MAX_FRAMES,
+          MAX_FRAMES + 1,
+          MAX_FRAMES / 3
+      );
+    }
+
+    @Test
+    public void whenTruncating21FramesEndChainItShouldLeave10HeadAnd10TailFrames() {
+      testChainTruncation(
+          MAX_FRAMES - 1,
+          MAX_FRAMES,
+          MAX_FRAMES,
+          MAX_FRAMES / 2,
+          MAX_FRAMES + 1);
+    }
+
+    @Test
+    public void whenTruncating21FramesInMultipleTracesItShouldLeave10HeadAnd10TailFrames() {
+      testChainTruncation(
+          MAX_FRAMES + 15,
+          MAX_FRAMES + 1,
+          MAX_FRAMES * 20,
+          MAX_FRAMES * 30
+      );
+    }
+  }
+
+  public static class TraceTest extends FramesStrategyTest {
+    @Test
+    public void whenFrameCountIsLessThan20ItShouldNotTruncate() {
+      testNoTruncation(MAX_FRAMES - 1);
+    }
+
+    @Test
+    public void whenFrameCountIs20ItShouldNotTruncate() {
+      testNoTruncation(MAX_FRAMES);
+    }
+
+    @Test
+    public void whenTruncating21FramesItShouldLeave10HeadAnd10TailFrames() {
+      testTraceTruncation(MAX_FRAMES + 1);
+    }
+
+    @Test
+    public void whenTruncatingManyFramesItShouldLeave10HeadAnd10TailFrames() {
+      testTraceTruncation(MAX_FRAMES * 30);
+    }
+  }
+
+  public static class GeneralTests extends FramesStrategyTest {
+    @Test
+    public void whenBodyIsMessageItShouldNotTruncate() {
+      Payload payload = builder.createTestPayload(
+          new Body.Builder()
+          .bodyContent(new Message.Builder().body("A message").build())
+          .build()
+      );
+
+      TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void whenBodyIsNullItShouldNotTruncate() {
+      Payload payload = builder.createTestPayload((Body) null);
+
+      TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void whenDataIsNullItShouldNotTruncate() {
+      Payload payload = new Payload.Builder(builder.createTestPayload())
+          .data(null)
+          .build();
+
+      TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+
+    @Test
+    public void ifTraceContainsNullFrameItShouldStillTruncate() {
+      // The body content itself cannot be null (the builders for each subclass will fail to build),
+      // but the frames can be null.
+      List<Frame> frames = new ArrayList<>();
+      frames.add(new Frame.Builder().method("test").filename("test").build());
+      frames.add(null);
+      for (int j = 0; j < 50; ++j) {
+        frames.add(new Frame.Builder().method("test" + j).filename("file" + j).build());
+      }
+
+      Payload payload = builder.createTestPayload(Collections.singletonList(frames));
+
+      TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(payload);
+      assertThat(result.wasTruncated, equalTo(true));
+
+      Trace trace = getBodyContentAs(Trace.class, result.value);
+
+      assertThat(trace.getFrames(), hasSize(20));
+      assertThat(trace.getFrames().get(0).getMethod(), equalTo("test"));
+      assertThat(trace.getFrames().get(19).getMethod(), equalTo("test49"));
+    }
+  }
+
+  protected void testNoTruncation(int... frameCounts) {
+    Payload original = createPayloadFromFrameCounts(frameCounts);
+
+    TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(original);
+    assertThat(result.wasTruncated, equalTo(false));
+    assertThat(result.value, nullValue());
+  }
+
+  protected void testChainTruncation(int... frameCounts) {
+    Payload original = createPayloadFromFrameCounts(frameCounts);
+
+    TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(original);
+    assertThat(result.wasTruncated, equalTo(true));
+
+    TraceChain chain = getBodyContentAs(TraceChain.class, result.value);
+    assertThat(chain.getTraces(), hasSize(frameCounts.length));
+
+    for (int j = 0; j < frameCounts.length; ++j) {
+      if (frameCounts[j] <= MAX_FRAMES) {
+        assertThat(chain.getTraces().get(j).getFrames(), hasSize(frameCounts[j]));
+      } else {
+        verifyTruncatedTrace(frameCounts[j], chain.getTraces().get(j));
+      }
+    }
+
+    assertThat(result.value, differsOnlyBy(original, new String[]{"data", "body", "trace_chain"}));
+  }
+
+  protected void testTraceTruncation(int frameCount) {
+    Payload original = builder.createTestPayloadSingleTrace(frameCount);
+    TruncationStrategy.TruncationResult<Payload> result = new FramesStrategy().truncate(original);
+    assertThat(result.wasTruncated, equalTo(true));
+
+    verifyTruncatedTrace(frameCount, getBodyContentAs(Trace.class, result.value));
+
+    // Our payload class is immutable, so a new one had to be built during truncation. We should
+    // verify that only the frames were modified.
+    assertThat(result.value, differsOnlyBy(original,
+        new String[]{"data", "body", "trace", "frames"}));
+  }
+
+  protected void verifyTruncatedTrace(int originalFrameCount, Trace actual) {
+    assertThat(actual.getFrames(), hasSize(MAX_FRAMES));
+
+    // The test payload uses the frame index as line number so we use it to check which frames were
+    // kept.
+
+    // Check head
+    for (int j = 0; j < HEAD_FRAMES; ++j) {
+      assertThat(actual.getFrames().get(j).getLineNumber(), equalTo(j));
+    }
+
+    // Check tail
+    for (int j = 0; j < TAIL_FRAMES; ++j) {
+      int frameIndex = j + HEAD_FRAMES;
+      int expectedLine = originalFrameCount - TAIL_FRAMES + j;
+      assertThat(actual.getFrames().get(frameIndex).getLineNumber(), equalTo(expectedLine));
+    }
+  }
+
+  private Payload createPayloadFromFrameCounts(int[] frameCounts) {
+    List<List<Frame>> traces = Arrays.stream(frameCounts).mapToObj(builder::createFrames)
+        .collect(Collectors.toList());
+
+    return new TestPayloadBuilder().createTestPayload(traces);
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/MinBodyStrategyTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/MinBodyStrategyTest.java
@@ -1,0 +1,296 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.body.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.rollbar.notifier.PayloadTestHelper.getBodyContentAs;
+import static com.rollbar.notifier.truncation.TestPayloadBuilder.makeString;
+import static com.rollbar.notifier.truncation.TruncationMatchers.differsOnlyBy;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public abstract class MinBodyStrategyTest {
+  protected final MinBodyStrategy sut = new MinBodyStrategy();
+
+  public static class GeneralTests extends MinBodyStrategyTest {
+    private TestPayloadBuilder payloadBuilder;
+
+    @Before
+    public void setUp() {
+      payloadBuilder = new TestPayloadBuilder();
+    }
+
+    @Test
+    public void ifBodyIsNullItShouldNotTruncate() {
+      Payload payload = payloadBuilder.createTestPayload((Body) null);
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void ifDataIsNullItShouldNotTruncate() {
+      Payload payload = new Payload.Builder(payloadBuilder.createTestPayload())
+          .data(null)
+          .build();
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void ifBodyContainsNoTraceItShouldNotTruncate() {
+      Payload payload = payloadBuilder.createTestPayload(
+          new Body.Builder()
+              .bodyContent(new Message.Builder().body("A message").build())
+              .build()
+      );
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void ifExceptionAndTraceAreTooSmallToBeTruncatedItShouldNotTruncate() {
+      List<Frame> frames = payloadBuilder.createFrames(2);
+      Trace trace = new Trace.Builder()
+          .frames(frames)
+          .exception(new ExceptionInfo.Builder()
+              .message("less than 255 chars")
+              .description(null)
+              .build())
+          .build();
+
+      Payload payload = payloadBuilder.createTestPayloadSingleTrace(trace);
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void ifExceptionAndChainAreTooSmallToBeTruncatedItShouldNotTruncate() {
+      Trace trace1 = new Trace.Builder()
+          .frames(payloadBuilder.createFrames(2))
+          .exception(new ExceptionInfo.Builder()
+              .message("fewer than 255 chars")
+              .description(null)
+              .build())
+          .build();
+
+      Trace trace2 = new Trace.Builder()
+          .frames(payloadBuilder.createFrames(1))
+          .exception(new ExceptionInfo.Builder()
+              .message("even fewer")
+              .description(null)
+              .build())
+          .build();
+
+      TraceChain chain = new TraceChain.Builder()
+          .traces(Arrays.asList(trace1, trace2))
+          .build();
+
+      Payload payload = payloadBuilder.createTestPayload(
+          new Body.Builder().bodyContent(chain).build()
+      );
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(false));
+      assertThat(result.value, nullValue());
+    }
+
+    @Test
+    public void ifSomeTracesAreTooLargeItShouldTruncate() {
+      Trace smallTrace = new Trace.Builder()
+          .frames(payloadBuilder.createFrames(1))
+          .exception(new ExceptionInfo.Builder()
+              .message("fewer than 255 chars")
+              .description(null)
+              .build())
+          .build();
+
+      Trace largeTrace = new Trace.Builder()
+          .frames(payloadBuilder.createFrames(30))
+          .exception(new ExceptionInfo.Builder()
+              .message("still fewer than 255")
+              .description(null)
+              .build())
+          .build();
+
+      TraceChain chain = new TraceChain.Builder()
+          .traces(Arrays.asList(smallTrace, largeTrace))
+          .build();
+
+      Payload payload = payloadBuilder.createTestPayload(
+          new Body.Builder().bodyContent(chain).build()
+      );
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(true));
+
+      TraceChain updatedChain = getBodyContentAs(TraceChain.class, result.value);
+
+      assertThat(updatedChain.getTraces(), hasSize(2));
+      assertThat(updatedChain.getTraces().get(0).getFrames(), hasSize(1));
+      assertThat(updatedChain.getTraces().get(1).getFrames(), hasSize(2));
+
+      assertThat(result.value, differsOnlyBy(payload,
+          new String[]{"data", "body", "trace_chain"}));
+    }
+
+    @Test
+    public void ifMessageIsTooLargeItShouldTruncate() {
+      List<Frame> frames = payloadBuilder.createFrames(2);
+      Trace trace = new Trace.Builder()
+          .frames(frames)
+          .exception(new ExceptionInfo.Builder()
+              .message(makeString("msg", 256))
+              .build())
+          .build();
+
+      Payload payload = payloadBuilder.createTestPayloadSingleTrace(trace);
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(true));
+
+      Trace updatedTrace = getBodyContentAs(Trace.class, result.value);
+      assertThat(updatedTrace.getException().getMessage().length(), equalTo(255));
+
+      assertThat(result.value, differsOnlyBy(payload,
+          new String[]{"data", "body", "trace", "exception", "message"}));
+    }
+
+    @Test
+    public void ifDescriptionIsSetItShouldTruncate() {
+      List<Frame> frames = payloadBuilder.createFrames(2);
+      Trace trace = new Trace.Builder()
+          .frames(frames)
+          .exception(new ExceptionInfo.Builder()
+              .message("abc")
+              .description("Any length is too long for this field")
+              .build())
+          .build();
+
+      Payload payload = payloadBuilder.createTestPayloadSingleTrace(trace);
+
+      TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+      assertThat(result.wasTruncated, equalTo(true));
+
+      Trace updatedTrace = getBodyContentAs(Trace.class, result.value);
+      assertThat(updatedTrace.getException().getDescription(), nullValue());
+
+      assertThat(result.value, differsOnlyBy(payload,
+          new String[]{"data", "body", "trace", "exception", "description"}));
+    }
+  }
+
+  public static class WhenTruncatingBigTrace extends MinBodyStrategyTest {
+    private TruncationStrategy.TruncationResult<Payload> result;
+    private Payload original;
+
+    @Before
+    public void setUp() {
+      TestPayloadBuilder payloadBuilder = new TestPayloadBuilder(1000);
+      original = payloadBuilder.createTestPayloadSingleTrace(50);
+      result = sut.truncate(original);
+    }
+
+    @Test
+    public void itShouldTruncate() {
+      assertThat(result.wasTruncated, equalTo(true));
+    }
+
+    @Test
+    public void itShouldKeep1HeadAnd1TailFrames() {
+      Trace trace = getBodyContentAs(Trace.class, result.value);
+
+      assertThat(trace.getFrames(), hasSize(2));
+
+      // The test payload builder uses frame index as line number
+      assertThat(trace.getFrames().get(0).getLineNumber(), equalTo(0));
+      assertThat(trace.getFrames().get(1).getLineNumber(), equalTo(49));
+    }
+
+    @Test
+    public void itShouldRemoveExceptionDescriptionAndTruncateMessage() {
+      Trace trace = getBodyContentAs(Trace.class, result.value);
+
+      ExceptionInfo exception = trace.getException();
+      assertThat(exception, not(nullValue()));
+
+      assertThat(exception.getDescription(), nullValue());
+      assertThat(exception.getMessage().length(), equalTo(255));
+    }
+
+    @Test
+    public void itShouldOnlyModifyBody() {
+      assertThat(result.value, differsOnlyBy(original, new String[] { "data", "body" }));
+    }
+  }
+
+  public static class WhenTruncatingChainWithBigTraces extends MinBodyStrategyTest {
+    private TruncationStrategy.TruncationResult<Payload> result;
+    private Payload original;
+
+    @Before
+    public void setUp() {
+      TestPayloadBuilder payloadBuilder = new TestPayloadBuilder(1000);
+      original = payloadBuilder.createTestPayload(
+          Arrays.asList(
+              payloadBuilder.createFrames(50),
+              payloadBuilder.createFrames(25),
+              payloadBuilder.createFrames(10)
+          )
+      );
+      result = sut.truncate(original);
+    }
+
+    @Test
+    public void itShouldTruncate() {
+      assertThat(result.wasTruncated, equalTo(true));
+    }
+
+    @Test
+    public void itShouldKeep1HeadAnd1TailFrames() {
+      TraceChain trace = getBodyContentAs(TraceChain.class, result.value);
+
+      assertThat(trace.getTraces(), hasSize(3));
+
+      // The test payload builder uses frame index as line number
+      assertThat(trace.getTraces().get(0).getFrames().get(0).getLineNumber(), equalTo(0));
+      assertThat(trace.getTraces().get(0).getFrames().get(1).getLineNumber(), equalTo(49));
+
+      assertThat(trace.getTraces().get(1).getFrames().get(0).getLineNumber(), equalTo(0));
+      assertThat(trace.getTraces().get(1).getFrames().get(1).getLineNumber(), equalTo(24));
+
+      assertThat(trace.getTraces().get(2).getFrames().get(0).getLineNumber(), equalTo(0));
+      assertThat(trace.getTraces().get(2).getFrames().get(1).getLineNumber(), equalTo(9));
+    }
+
+    @Test
+    public void itShouldRemoveExceptionDescriptionAndTruncateMessage() {
+      TraceChain chain = getBodyContentAs(TraceChain.class, result.value);
+
+      for (Trace trace : chain.getTraces()) {
+        ExceptionInfo exception = trace.getException();
+        assertThat(exception, not(nullValue()));
+
+        assertThat(exception.getDescription(), nullValue());
+        assertThat(exception.getMessage().length(), equalTo(255));
+      }
+    }
+
+    @Test
+    public void itShouldOnlyModifyBody() {
+      assertThat(result.value, differsOnlyBy(original, new String[] { "data", "body" }));
+    }
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/PayloadTruncatorTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/PayloadTruncatorTest.java
@@ -1,0 +1,123 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.notifier.sender.json.JsonSerializer;
+import com.rollbar.notifier.sender.json.JsonSerializerImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.rollbar.notifier.truncation.TruncationMatchers.hasNoStringsLongerThan;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class PayloadTruncatorTest {
+  private JsonSerializer serializer;
+  private PayloadTruncator truncator;
+  private int maxPayloadSizeBytes;
+  private TestPayloadBuilder builder;
+
+  @Before
+  public void setUp() {
+    serializer = new JsonSerializerImpl();
+    truncator = new PayloadTruncator(serializer);
+    maxPayloadSizeBytes = 1024 * 512;
+    builder = new TestPayloadBuilder();
+  }
+
+  @Test
+  public void whenPayloadIsWithinLimitItShouldNotBeTruncated() {
+    Payload payload = builder.createTestPayload();
+
+    String original = serializer.toJson(payload);
+
+    // Ensure test is valid
+    assertThat(PayloadTruncator.sizeInBytes(original), lessThanOrEqualTo(maxPayloadSizeBytes));
+
+    Payload result = truncator.truncate(payload, maxPayloadSizeBytes).getPayload();
+    String updated = serializer.toJson(result);
+
+    assertThat(TestString.of(updated), equalTo(TestString.of(original)));
+  }
+
+  @Test
+  public void whenPayloadIsLargerThanLimitDueToTraceItShouldBeTruncated() {
+    Payload payload = builder.createTestPayloadSingleTrace(5000);
+
+    String original = serializer.toJson(payload);
+
+    // Ensure the test is valid
+    assertThat(PayloadTruncator.sizeInBytes(original), greaterThan(maxPayloadSizeBytes));
+
+    Payload result = truncator.truncate(payload, maxPayloadSizeBytes).getPayload();
+    String updated = serializer.toJson(result);
+
+    assertThat(TestString.of(updated), not(equalTo(TestString.of(original))));
+
+    assertThat(PayloadTruncator.sizeInBytes(updated), lessThanOrEqualTo(maxPayloadSizeBytes));
+  }
+
+  @Test
+  public void whenPayloadIsLargerThanLimitDueToTraceChainItShouldBeTruncated() {
+    Payload payload = builder.createTestPayload(
+        Arrays.asList(
+            builder.createFrames(2500),
+            builder.createFrames(2500)
+        )
+    );
+
+    String original = serializer.toJson(payload);
+
+    // Ensure the test is valid
+    assertThat(PayloadTruncator.sizeInBytes(original), greaterThan(maxPayloadSizeBytes));
+
+    Payload result = truncator.truncate(payload, maxPayloadSizeBytes).getPayload();
+    String updated = serializer.toJson(result);
+
+    assertThat(TestString.of(updated), not(equalTo(TestString.of(original))));
+
+    assertThat(PayloadTruncator.sizeInBytes(updated), lessThanOrEqualTo(maxPayloadSizeBytes));
+  }
+
+  @Test
+  public void whenPayloadIsLargerThanLimitDueToLargeStringsItShouldBeTruncated() {
+    builder = new TestPayloadBuilder(30000);
+    Payload payload = builder.createTestPayloadSingleTrace(5);
+
+    String original = serializer.toJson(payload);
+
+    // Ensure the test is valid
+    assertThat(PayloadTruncator.sizeInBytes(original), greaterThan(maxPayloadSizeBytes));
+
+    Payload result = truncator.truncate(payload, maxPayloadSizeBytes).getPayload();
+    String updated = serializer.toJson(result);
+
+    assertThat(TestString.of(updated), not(equalTo(TestString.of(original))));
+
+    assertThat(PayloadTruncator.sizeInBytes(updated), lessThanOrEqualTo(maxPayloadSizeBytes));
+    assertThat(result, hasNoStringsLongerThan(1024));
+  }
+
+  @Test
+  public void whenPayloadIsTooLargeDueToManyStringsItShouldApplyMoreAggressiveTruncation() {
+    // Adjust the number of custom fields as necessary if the payload structure changes. The goal
+    // is to produce a payload larger than the maximum size, that can be brought down below the
+    // limit by truncating all strings to 256 characters.
+    builder = new TestPayloadBuilder(300, 1800);
+    Payload payload = builder.createTestPayloadSingleTrace(5);
+
+    String original = serializer.toJson(payload);
+
+    // Ensure the test is valid
+    assertThat(PayloadTruncator.sizeInBytes(original), greaterThan(maxPayloadSizeBytes));
+
+    Payload result = truncator.truncate(payload, maxPayloadSizeBytes).getPayload();
+    String updated = serializer.toJson(result);
+
+    assertThat(TestString.of(updated), not(equalTo(TestString.of(original))));
+
+    assertThat(PayloadTruncator.sizeInBytes(updated), lessThanOrEqualTo(maxPayloadSizeBytes));
+    assertThat(result, hasNoStringsLongerThan(256));
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/StringsStrategyTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/StringsStrategyTest.java
@@ -1,0 +1,47 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.body.Body;
+import org.junit.Test;
+
+import static com.rollbar.notifier.truncation.TruncationMatchers.hasNoStringsLongerThan;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class StringsStrategyTest {
+  @Test
+  public void whenTruncatingAllStringsShouldHaveSizeLessOrEqualToLimit() {
+    TestPayloadBuilder builder = new TestPayloadBuilder(1025);
+
+    Payload payload = builder.createTestPayloadSingleTrace(5);
+    TruncationStrategy.TruncationResult<Payload> result = new StringsStrategy(1024)
+        .truncate(payload);
+
+    assertThat(result.wasTruncated, equalTo(true));
+    assertThat(result.value, hasNoStringsLongerThan(1024));
+  }
+
+  @Test
+  public void whenBodyIsNullItShouldTruncateOtherElements() {
+    Payload payload = new TestPayloadBuilder(1024).createTestPayload((Body) null);
+
+    TruncationStrategy.TruncationResult<Payload> result = new StringsStrategy(1024)
+        .truncate(payload);
+
+    assertThat(result.wasTruncated, equalTo(true));
+    assertThat(result.value, hasNoStringsLongerThan(1024));
+  }
+
+  @Test
+  public void whenDataIsNullItShouldNotTruncate() {
+    Payload payload = new Payload.Builder(new TestPayloadBuilder().createTestPayload())
+        .data(null)
+        .build();
+
+    TruncationStrategy.TruncationResult<Payload> result = new StringsStrategy(1024)
+        .truncate(payload);
+    assertThat(result.wasTruncated, equalTo(false));
+    assertThat(result.value, nullValue());
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestPayloadBuilder.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestPayloadBuilder.java
@@ -1,0 +1,153 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.*;
+import com.rollbar.api.payload.data.body.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TestPayloadBuilder {
+  private final int stringLength;
+  private final int customLength;
+
+  public TestPayloadBuilder() {
+    this(-1);
+  }
+
+  public TestPayloadBuilder(int stringLength) {
+    this(stringLength, 10);
+  }
+
+  public TestPayloadBuilder(int stringLength, int customLength) {
+    this.stringLength = stringLength;
+    this.customLength = customLength;
+  }
+
+  public Payload createTestPayload() {
+    return createTestPayloadSingleTrace(new ArrayList<>());
+  }
+
+  public Payload createTestPayloadSingleTrace(int frameCount) {
+    return createTestPayloadSingleTrace(createFrames(frameCount));
+  }
+
+  public Payload createTestPayloadSingleTrace(Trace trace) {
+    return createTestPayload(new Body.Builder().bodyContent(trace).build());
+  }
+
+  public Payload createTestPayloadSingleTrace(List<Frame> frameList) {
+    return createTestPayload(Collections.singletonList(frameList));
+  }
+
+  public Payload createTestPayload(List<List<Frame>> frameLists) {
+    List<Trace> traces = frameLists.stream().map(frameList -> new Trace.Builder()
+        .exception(
+            new ExceptionInfo.Builder()
+                .message(makeString("Error"))
+                .description(makeString("some error"))
+                .className(makeString("com.example.TestException"))
+                .build()
+        )
+        .frames(frameList)
+        .build()).collect(Collectors.toList());
+
+    BodyContent bodyContent;
+    if (traces.size() == 1) {
+      bodyContent = traces.get(0);
+    } else {
+      bodyContent = new TraceChain.Builder().traces(traces).build();
+    }
+
+    return createTestPayload(new Body.Builder().bodyContent(bodyContent).build());
+  }
+
+  public Payload createTestPayload(Body body) {
+    return new Payload.Builder().data(
+        new Data.Builder()
+            .client(
+                new Client.Builder()
+                    .addClient("client", "some_prop", 42)
+                    .addClient("client_b", "prop_b", makeString("test"))
+                    .build()
+            )
+            .codeVersion(makeString("9.999942"))
+            .environment(makeString("unit_testing"))
+            .framework(makeString("junit"))
+            .person(
+                new Person.Builder()
+                    .username(makeString("some username"))
+                    .metadata(makeMap(5))
+                    .email(makeString("test@test.com"))
+                    .build()
+            )
+            .custom(makeMap(customLength))
+            .level(Level.WARNING)
+            .context(makeString("ABC"))
+            .language(makeString("java"))
+            .platform(makeString("BeOS"))
+            .person(new Person.Builder().username(makeString("test-user")).build())
+            .server(new Server.Builder().root(makeString("/server/root")).build())
+            .client(
+                new Client.Builder()
+                    .addClient("a", "b", makeString("some value"))
+                    .addTopLevel("c", makeString("another value"))
+                    .build()
+            )
+            .body(body)
+            .build()
+    ).build();
+  }
+
+  private Map<String, Object> makeMap(int length) {
+    HashMap<String, Object> map = new HashMap<>();
+    map.put("non-string", 20);
+    for (int j = 0; j < length; ++j) {
+      map.put("loop-key-" + j, makeString("value" + j));
+    }
+    return map;
+  }
+
+  public List<Frame> createFrames(int frameCount) {
+    ArrayList<Frame> frames = new ArrayList<>();
+    for (int j = 0; j < frameCount; ++j) {
+      frames.add(
+          new Frame.Builder()
+              .filename(makeString("/src/test/input" + j))
+              .className(makeString("com.rollbar.test.Class" + j))
+              // Use frame index a line and column number, which can be used to verify truncation
+              .lineNumber(j)
+              .columnNumber(j)
+              .method(makeString("CallMethod" + j))
+              .build()
+      );
+    }
+
+    return frames;
+  }
+
+  public String makeString(String baseString) {
+    return makeString(baseString, this.stringLength);
+  }
+
+  public static String makeString(String baseString, int stringLength) {
+    if (stringLength < 0) {
+      return baseString;
+    } else {
+      StringBuilder sb = new StringBuilder();
+      int baseLength = baseString.length();
+      int remaining = stringLength;
+      while (remaining > 0) {
+        if (baseLength <= remaining) {
+          sb.append(baseString);
+          remaining -= baseLength;
+        } else {
+          sb.append(baseString, 0, remaining);
+          remaining = 0;
+        }
+      }
+
+      return sb.toString();
+    }
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestString.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestString.java
@@ -1,0 +1,58 @@
+package com.rollbar.notifier.truncation;
+
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * IntelliJ locks up on the assert output if the string is too large, so we wrap the strings and
+ * make them something that can be displayed.
+ */
+class TestString {
+  private static final MessageDigest MD5;
+
+  private final String value;
+
+  static {
+    try {
+      MD5 = MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private TestString(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TestString that = (TestString) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override
+  public String toString() {
+    Charset UTF8 = Charset.forName("UTF-8");
+    if (value == null) {
+      return "";
+    } else {
+      byte[] hashBytes = MD5.digest(value.getBytes(UTF8));
+      String hashString = Base64.getEncoder().encodeToString(hashBytes);
+      return hashString + ":" + value.substring(0, Math.min(100, value.length()));
+    }
+  }
+
+  public static TestString of(String value) {
+    return new TestString(value);
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TruncationMatchers.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TruncationMatchers.java
@@ -98,7 +98,6 @@ public class TruncationMatchers {
     };
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   private static String findStringLongerThan(Object value, int length) {
     if (value == null) {
       return null;
@@ -110,7 +109,9 @@ public class TruncationMatchers {
         return (String) value;
       }
     } else if (value instanceof Iterable) {
-      for (Object element : (Iterable) value) {
+      @SuppressWarnings("rawtypes")
+      Iterable valueAsIterable = (Iterable) value;
+      for (Object element : valueAsIterable) {
         String result = findStringLongerThan(element, length);
         if (result != null) {
           return result;
@@ -126,7 +127,9 @@ public class TruncationMatchers {
         }
       }
     } else if (value instanceof Map) {
-      for (Map.Entry<String, Object> entry : ((Map<String, Object>)value).entrySet()) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> valueAsMap = (Map<String, Object>) value;
+      for (Map.Entry<String, Object> entry : valueAsMap.entrySet()) {
         String result = findStringLongerThan(entry.getValue(), length);
         if (result != null) {
           return result;

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TruncationMatchers.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TruncationMatchers.java
@@ -1,0 +1,192 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.payload.Payload;
+import com.rollbar.notifier.sender.json.JsonSerializerImpl;
+import com.rollbar.notifier.sender.json.JsonTestHelper;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class TruncationMatchers {
+  private static final JsonSerializerImpl SERIALIZER = new JsonSerializerImpl();
+
+  /**
+   * Checks that a Payload instance matches the expected value, excluding the provided path,
+   * which can differ.
+   *
+   * @param expected        The expected value.
+   * @param pathThatDiffers The path that is allowed to be different between expected and actual.
+   * @return A Matcher instance that verifies the assertion.
+   */
+  public static Matcher<Payload> differsOnlyBy(Payload expected, String[] pathThatDiffers) {
+    final TestString expectedJson = getJsonString(expected, pathThatDiffers);
+    final Matcher<Object> instanceMatcher = instanceOf(Payload.class);
+    final Matcher<TestString> valueMatcher = equalTo(expectedJson);
+
+    return new BaseMatcher<Payload>() {
+      @Override
+      public boolean matches(Object item) {
+        if (!instanceMatcher.matches(item)) {
+          return false;
+        }
+
+        Payload actual = (Payload) item;
+        TestString otherJson = getJsonString(actual, pathThatDiffers);
+
+        return valueMatcher.matches(otherJson);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Payload with JSON value " + expectedJson);
+      }
+
+      @Override
+      public void describeMismatch(Object item, Description description) {
+        if (!instanceMatcher.matches(item)) {
+          instanceMatcher.describeMismatch(item, description);
+        } else {
+          Payload actual = (Payload) item;
+          TestString otherJson = getJsonString(actual, pathThatDiffers);
+
+          valueMatcher.describeMismatch(otherJson, description);
+        }
+      }
+    };
+  }
+
+  public static Matcher<Payload> hasNoStringsLongerThan(int length) {
+    final Matcher<Object> instanceMatcher = instanceOf(Payload.class);
+
+    return new BaseMatcher<Payload>() {
+      @Override
+      public boolean matches(Object item) {
+        if (!instanceMatcher.matches(item)) {
+          return false;
+        }
+
+        String longString = findStringLongerThan(item, length);
+        return longString == null;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Payload with all strings of length " + length + " or shorter.");
+      }
+
+      @Override
+      public void describeMismatch(Object item, Description description) {
+        if (!instanceMatcher.matches(item)) {
+          instanceMatcher.describeMismatch(item, description);
+        } else {
+          Payload actual = (Payload) item;
+          String longString = findStringLongerThan(actual, length);
+          description.appendText("Found string with length " + longString.length() +
+              ": " + longString);
+        }
+      }
+    };
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static String findStringLongerThan(Object value, int length) {
+    if (value == null) {
+      return null;
+    } else if (value instanceof Payload) {
+      // By converting to a JSON map we can be sure we're checking every string, recursively.
+      return findStringLongerThan(toJsonMap((Payload) value), length);
+    } else if (value instanceof String) {
+      if (((String) value).length() > length) {
+        return (String) value;
+      }
+    } else if (value instanceof Iterable) {
+      for (Object element : (Iterable) value) {
+        String result = findStringLongerThan(element, length);
+        if (result != null) {
+          return result;
+        }
+      }
+    } else if (value.getClass().isArray()) {
+      int arrayLength = Array.getLength(value);
+      for (int j = 0; j < arrayLength; ++j) {
+        Object element = Array.get(value, j);
+        String result = findStringLongerThan(element, length);
+        if (result != null) {
+          return result;
+        }
+      }
+    } else if (value instanceof Map) {
+      for (Map.Entry<String, Object> entry : ((Map<String, Object>)value).entrySet()) {
+        String result = findStringLongerThan(entry.getValue(), length);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private static Map<String, Object> toJsonMap(Payload value) {
+    String json = SERIALIZER.toJson(value);
+    return JsonTestHelper.fromString(json);
+  }
+
+  private static TestString getJsonString(Payload payload, String[] ignoredPath) {
+    Map<String, Object> otherMap = toPlainObjects(payload.asJson());
+    replaceWithNull(otherMap, ignoredPath);
+    return TestString.of(SERIALIZER.toJson(otherMap));
+  }
+
+  private static Map<String, Object> toPlainObjects(Map<String, Object> values) {
+    Map<String, Object> result = new HashMap<>();
+    for (String k : values.keySet()) {
+      Object value = values.get(k);
+      if (value instanceof JsonSerializable) {
+        value = ((JsonSerializable) value).asJson();
+      }
+      result.put(k, toPlainObject(value));
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Object toPlainObject(Object jsonObject) {
+    if (jsonObject instanceof Map) {
+      return toPlainObjects((Map<String, Object>) jsonObject);
+    } else if (jsonObject instanceof Iterable) {
+      List<Object> newElements = new ArrayList<>();
+      for (Object element : ((Iterable<Object>) jsonObject)) {
+        newElements.add(toPlainObject(element));
+      }
+      return newElements.toArray(new Object[0]);
+    } else {
+      return jsonObject;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void replaceWithNull(Map<String, Object> map, String[] path) {
+    Map<String, Object> current = map;
+    for (int j = 0; ; ++j) {
+      String key = path[j];
+
+      if (j == path.length - 1) {
+        current.put(key, null);
+        return;
+      }
+
+      current = (Map<String, Object>) current.get(key);
+    }
+  }
+}

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/config/ConfigBuilder.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/config/ConfigBuilder.java
@@ -58,6 +58,7 @@ public final class ConfigBuilder {
   private boolean handleUncaughtErrors;
   private boolean enabled;
   private DefaultLevels defaultLevels;
+  private boolean truncateLargePayloads;
 
   /**
    * Constructor with an access token.
@@ -98,6 +99,7 @@ public final class ConfigBuilder {
     this.endpoint = config.endpoint();
     this.appPackages = config.appPackages();
     this.defaultLevels = new DefaultLevels(config);
+    this.truncateLargePayloads = config.truncateLargePayloads();
   }
 
   private ConfigBuilder(Sender sender) {
@@ -447,6 +449,19 @@ public final class ConfigBuilder {
   }
 
   /**
+   * <p>
+   * If set to true, the notifier will attempt to truncate payloads that are larger than the
+   * maximum size Rollbar allows. Default: false.
+   * </p>
+   * @param truncate true to enable truncation.
+   * @return the builder instance.
+   */
+  public ConfigBuilder truncateLargePayloads(boolean truncate) {
+    this.truncateLargePayloads = truncate;
+    return this;
+  }
+
+  /**
    * Builds the {@link Config config}.
    *
    * @return the config.
@@ -508,6 +523,8 @@ public final class ConfigBuilder {
     private final boolean handleUncaughtErrors;
     private final boolean enabled;
     private final DefaultLevels defaultLevels;
+    private final JsonSerializer jsonSerializer;
+    private final boolean truncateLargePayloads;
 
     ConfigImpl(ConfigBuilder builder) {
       this.accessToken = builder.accessToken;
@@ -538,6 +555,8 @@ public final class ConfigBuilder {
       this.handleUncaughtErrors = builder.handleUncaughtErrors;
       this.enabled = builder.enabled;
       this.defaultLevels = builder.defaultLevels;
+      this.jsonSerializer = builder.jsonSerializer;
+      this.truncateLargePayloads = builder.truncateLargePayloads;
     }
 
     @Override
@@ -636,6 +655,11 @@ public final class ConfigBuilder {
     }
 
     @Override
+    public JsonSerializer jsonSerializer() {
+      return jsonSerializer;
+    }
+
+    @Override
     public Sender asyncSender() {
       return asyncSender;
     }
@@ -668,6 +692,11 @@ public final class ConfigBuilder {
     @Override
     public Level defaultThrowableLevel() {
       return defaultLevels.getThrowable();
+    }
+
+    @Override
+    public boolean truncateLargePayloads() {
+      return truncateLargePayloads;
     }
   }
 }


### PR DESCRIPTION
## Description of the change

Add option to truncate payloads before sending them to Rollbar.

The implementation is similar to the one found rollbar-gem and Rollbar.NET.
Truncation is disabled by default to maintain backwards compatibility.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- [ch92078]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
