### PR TITLE
Disable vmlens tests when running in Java 11, since it occasionally g…

### DIFF
--- a/rollbar-reactive-streams-reactor/build.gradle
+++ b/rollbar-reactive-streams-reactor/build.gradle
@@ -73,6 +73,12 @@ project.tasks.check.dependsOn(junit4Test)
 interleave {
     useJUnit() {
         includeCategories VMLENS_CATEGORY
+
+        // VMLens occasionally generates invalid bytecode under Java > 8. This will either be fixed,
+        // or VMLens will have to be removed. For now we need consistent builds, and the concurrency
+        // code we test under Java 8 has the same semantics under Java 11 so testing only Java 8 is
+        // an acceptable compromise.
+        enabled = JavaVersion.current().compareTo(JavaVersion.VERSION_1_9) < 0
     }
 
     // The Jacoco agent doesn't get along with the VMLens agent.


### PR DESCRIPTION
## Description of the change

Disable VMLens tests when running in Java 11, since it occasionally generates invalid bytecode. 

Longer term we will need to consider removing VMLens, since it hasn't seen much support recently. There is no replacement for it so concurrency tests that rely on VMLens would also need to be removed. 

For now we run the tests under Java 8, where they work consistently. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- Fix [ch93597]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
