### PR TITLE
log4j 2.15.0 - fixes security vulnerability CVE-2021-44228 (#285)

### DIFF
--- a/rollbar-log4j2/build.gradle
+++ b/rollbar-log4j2/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     api project(':rollbar-java')
 
-    api group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
-    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.11.0'
+    api group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
+    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.15.0'
 }


### PR DESCRIPTION
## Description of the change

Updates log4j2 to remediate [security vulnerability CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in <2.15.0

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix #285 

## Checklists

### Development

As this is only a minor dependency update, it would not have affected any linting or tests. If anyone has this project set up to verify them, please do.

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
