### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 1.8.0
+
+- Update log4j dependencies to v 2.16.0 (#287)
+- log4j 2.15.0 - fixes security vulnerability CVE-2021-44228 (#285) (#286)
+  This change removes Java 7 compatibility for `rollbar-log4j2`. See [rollbar-log4j2/README.md](rollbar-log4j2/README.md) for more details.
+- Update PR template (#284)
+
 # 1.7.10
 
 - Add option to truncate payloads before sending them to Rollbar.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7.11-SNAPSHOT
+VERSION_NAME=1.8.0
 GROUP=com.rollbar
 
 POM_DESCRIPTION=For connecting your applications built on the JVM to Rollbar for Error Reporting

--- a/rollbar-log4j2/README.md
+++ b/rollbar-log4j2/README.md
@@ -1,0 +1,28 @@
+# Rollbar Log4j 2 integration
+
+This directory contains the Log4j 2 integration of the Rollbar Java SDK. 
+
+Instructions for building and contributing to the SDK can be found in the main repository [README](../README.md).
+
+## Compatibility
+
+Staring with version `1.8.0`, `rollbar-log4j2` depends on version `2.16.0` of `log4j-core`. This removes compatibility with Java 7, but was a necessary upgrade to fix the CVE-2021-44228 vulnerability in Log4j. 
+
+Projects built and / or running with Java 7 can still use `rollbar-log4j2` version `1.8.0`, while forcing the use of a **vulnerable**, Java 7 compatible version of `Log4j`, by updating their build configuration to ignore transitive dependencies from `rollbar-log4j2`. 
+
+Gradle configuration:
+
+```gradle
+dependencies {
+    implementation(group: 'com.rollbar', name: 'rollbar-log4j2', version: '1.8.0') {
+        exclude group: 'org.apache.logging.log4j'
+    }
+
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.12.1'
+    annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.12.1'
+}
+
+```
+
+Note CVE-2021-44228 is a major RCE vulnerability and this approach should only be used after a thorough security analysis, and with very strong mitigations in place.
+


### PR DESCRIPTION
## Description of the change

Release version 1.8.0

This includes some necessary breaking changes in `rollbar-log4j2` caused by CVE-2021-44228. See the rollbar-log4j2 [README](./rollbar-log4j2/README.md) for details.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
