### PR TITLE
Nexus publishing: increase timeout during transition checks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,8 @@ nexusStaging {
     packageGroup = GROUP
     username = System.getenv('NEXUS_USERNAME')
     password = System.getenv('NEXUS_PASSWORD')
-    numberOfRetries = 60
+    numberOfRetries = 180
+    delayBetweenRetriesInMillis = 3000
 }
 
 allprojects {


### PR DESCRIPTION
## Description of the change

Nexus publishing: increase timeout during transition checks.

- Increase number of attempts from 60 to 180
- Increase delay between attempts from 2 to 3 seconds

This increases the total timeout from 2 to 9 minutes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [x] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
