### PR TITLE
Update log4j dependencies to v2.17.0

### DIFF
--- a/examples/rollbar-log4j2/build.gradle
+++ b/examples/rollbar-log4j2/build.gradle
@@ -12,5 +12,5 @@ application {
 dependencies {
     implementation project(":rollbar-log4j2")
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.8.0
+VERSION_NAME=1.8.1-SNAPSHOT
 GROUP=com.rollbar
 
 POM_DESCRIPTION=For connecting your applications built on the JVM to Rollbar for Error Reporting

--- a/rollbar-log4j2/build.gradle
+++ b/rollbar-log4j2/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     api project(':rollbar-java')
 
-    api group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
-    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.16.0'
+    api group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
+    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.17.0'
 }


### PR DESCRIPTION
## Description of the change

Update log4j dependencies to v2.17.0 to remediate CVE-2021-45105

Note: This PR is built on top of #290

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- CVE-2021-45105

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
