### PR TITLE
Enable maven publishing for rollbar-reactive-streams and rollbar-reac…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,7 @@ subprojects { project ->
             !project.name.contains('examples')) {
         apply plugin: 'java-library'
 
-        // reactive-streams support will be published along with Spring Webflux 
-        if (!project.name.startsWith('rollbar-reactive-streams')) {
-            apply from: "$rootDir/gradle/release.gradle"
-        }
+        apply from: "$rootDir/gradle/release.gradle"
 
         apply from: "$rootDir/gradle/quality.gradle"
         


### PR DESCRIPTION
## Description of the change

Enable maven publishing for rollbar-reactive-streams and rollbar-reactive-streams-reactor artifacts.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- [sc116280]

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
