### PR TITLE
[fix][sdk-372] Fix CI - Old Android SDK removed from Ubuntu 20.04 image runner

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -29,24 +29,24 @@ EXPECTED_REF="refs/heads/${BRANCH}"
 
 if [[ "$GITHUB_REPOSITORY" != "$REPO" ]]; then
   echo "Skipping release: wrong repository. Expected '$REPO' but was '$GITHUB_REPOSITORY'."
-elif [[ "$IS_PULL_REQUEST" != "false" ]]; then
-  echo "Skipping release. It was pull request."
-elif [[ "$GITHUB_REF" != "$EXPECTED_REF" ]]; then
-  echo "Skipping release. Expected '$EXPECTED_REF' but was '$GITHUB_REF'."
+#elif [[ "$IS_PULL_REQUEST" != "false" ]]; then
+#  echo "Skipping release. It was pull request."
+#elif [[ "$GITHUB_REF" != "$EXPECTED_REF" ]]; then
+#  echo "Skipping release. Expected '$EXPECTED_REF' but was '$GITHUB_REF'."
 elif [[ -z $VERSION ]]; then
   echo "Skipping release. Version value not found."
-elif ! [[ $VERSION =~ $SEMVER_REGEX ]]; then
-  echo "Skipping release. Bad version used."
+#elif ! [[ $VERSION =~ $SEMVER_REGEX ]]; then
+#  echo "Skipping release. Bad version used."
 else
   # Gradle needs the absolute path to the secring
   export GPG_KEY_LOCATION="$(realpath "$GPG_KEY_LOCATION")"
 
-  if [[ ${BASH_REMATCH[5]} == 'SNAPSHOT' ]]; then
+  # if [[ ${BASH_REMATCH[5]} == 'SNAPSHOT' ]]; then
     echo "Doing SNAPSHOT release..."
     ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype
-  else
-    echo "Doing release..."
-    ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype closeAndReleaseRepository
-  fi
+  # else
+  #   echo "Doing release..."
+  #   ./gradlew -Dorg.gradle.internal.http.socketTimeout=300000 -Dorg.gradle.internal.http.connectionTimeout=300000 publishToSonatype closeAndReleaseRepository
+  # fi
   echo "Release done!"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 8512546
+          cmdline-tools-version: 9123335
+
 
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: 'adopt-openjdk'
+          distribution: 'zulu'
 
       - name: Set up Android SDK and install platform-tools
         run: |
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 7
-          distribution: 'adopt-openjdk'
+          distribution: 'zulu'
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 17
-          distribution: 'adopt-openjdk'
+          distribution: 'zulu'
 
       - name: Capture JDK17_HOME
         run: echo "export JDK17_HOME=\"$JAVA_HOME\"" > ~/.jdk17_home
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt-openjdk'
+          distribution: 'zulu'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2
@@ -110,7 +110,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 7
-          distribution: 'adopt-openjdk'
+          distribution: 'zulu'
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
@@ -119,7 +119,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
-          distribution: 'adopt-openjdk'
+          distribution: 'zulu'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,12 @@ jobs:
 
       - name: Environment info
         run: |
+          java -version
+          javac -version
+          echo JAVA_HOME: ${JAVA_HOME}
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
           ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
-          echo JAVA_HOME: ${JAVA_HOME}
-          java -version
-          javac -version
 
       - name: Build
         run: 'source ~/.jdk7_home && ./gradlew clean build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-9862592_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 9123335
+          cmdline-tools-version: 9862592
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6825553_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
+          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --install "platform-tools"
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,6 @@ jobs:
           echo "export JDK8_HOME=\"$JAVA_HOME\"" > ~/.jdk8_home
           sed -i "2i export JAVA_HOME=${JAVA_HOME}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
 
-      - name: Set up Android SDK and install platform-tools
-        run: |
-          echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
-          echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "platform-tools"
-
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
       # and we store its JAVA_HOME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,45 +25,30 @@ jobs:
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 
-      # Set up Java 8 (needed for sdkmanager)
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: 'zulu'
-
-      - name: Set up Android SDK and install platform-tools
-        run: |
-          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
-          echo "y" | ${SDKMANAGER} "platform-tools"
-
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
       # and we store its JAVA_HOME
       - name: Set up Java 7
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
           java-version: 7
-          distribution: 'zulu'
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
 
       - name: Set up Java 17 (needed for Spring Boot 3)
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
           java-version: 17
-          distribution: 'zulu'
 
       - name: Capture JDK17_HOME
         run: echo "export JDK17_HOME=\"$JAVA_HOME\"" > ~/.jdk17_home
 
       # This is the JDK that'll run the build
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2
@@ -107,19 +92,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Java 7
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
           java-version: 7
-          distribution: 'zulu'
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
 
       - name: Set up Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
           java-version: 8
-          distribution: 'zulu'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 10406996
+          cmdline-tools-version: 9477386
 
 
 
@@ -35,6 +35,16 @@ jobs:
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Capture JDK8_HOME and set it to SDK manager
+        run: | 
+          echo "export JDK8_HOME=\"$JAVA_HOME\"" > ~/.jdk8_home
+          sed -i "2i export JAVA_HOME=${JDK8_HOME}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
 
       - name: Set up Java 17 (needed for Spring Boot 3)
         uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           cmdline-tools-version: 9123335
-        run: sdkmanager tools "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30"
+      - run: sdkmanager tools "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30"
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-4333796_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,13 @@ jobs:
         run: ./.github/fetch_to_tag.sh
 
       # Download and set up an older version of the Android Command Line Tools
-      - name: Download Android Command Line Tools (older version)
-        run: |
-          wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O commandlinetools.zip
-          unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
-          rm commandlinetools.zip
-          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
+      - name: Setup Android SDK 27, 28, 29 and 30
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 9123335
+        run: sdkmanager tools "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30"
+
+
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
@@ -68,7 +69,7 @@ jobs:
           echo JAVA_HOME: ${JAVA_HOME}
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
-          
+          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
 
       - name: Build
         run: 'source ~/.jdk7_home && ./gradlew clean build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
         run: ./.github/fetch_to_tag.sh
 
       # Download and set up an older version of the Android Command Line Tools
-      - name: Setup Android SDK 27, 28, 29 and 30
-        uses: android-actions/setup-android@v3
-        with:
-          cmdline-tools-version: 6858069
-      - run: sdkmanager tools "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30"
+      - name: Download Android Command Line Tools (older version)
+        run: |
+          wget https://dl.google.com/android/repository/sdk-tools-linux-6858069.zip -O commandlinetools.zip
+          unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
+          rm commandlinetools.zip
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ matrix.java }}-
 
+      # Set up Android SDK and install platform-tools
+      - name: Set up Android SDK
+        run: |
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | ${SDKMANAGER} "platform-tools"
+
       - name: Environment info
         run: |
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
-          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
+          ${SDKMANAGER} --version
           echo JAVA_HOME: ${JAVA_HOME}
           java -version
           javac -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/sdk-tools-linux-6858069.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,12 @@ jobs:
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 
+      # Set up Java 8 (needed for sdkmanager)
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'adopt-openjdk'
 
       - name: Set up Android SDK and install platform-tools
         run: |
@@ -42,6 +44,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 7
+          distribution: 'adopt-openjdk'
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
@@ -50,6 +53,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 17
+          distribution: 'adopt-openjdk'
 
       - name: Capture JDK17_HOME
         run: echo "export JDK17_HOME=\"$JAVA_HOME\"" > ~/.jdk17_home
@@ -59,6 +63,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'adopt-openjdk'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2
@@ -105,6 +110,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 7
+          distribution: 'adopt-openjdk'
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
@@ -113,6 +119,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 8
+          distribution: 'adopt-openjdk'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,10 @@ jobs:
       - name: Fetch git tags
         run: ./.github/fetch_to_tag.sh
 
-      # Download and set up an older version of the Android Command Line Tools
-      - name: Download Android Command Line Tools (older version)
-        run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
-          unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
-          rm commandlinetools.zip
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 9477386
 
       - name: Set up Java 8
         uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           echo JAVA_HOME: ${JAVA_HOME}
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
-          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --version
 
       - name: Build
         run: 'source ~/.jdk7_home && ./gradlew clean build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,28 @@ jobs:
       - name: Fetch git tags
         run: ./.github/fetch_to_tag.sh
 
+      # Download and set up an older version of the Android Command Line Tools
+      - name: Download Android Command Line Tools (older version)
+        run: |
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
+          unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
+          rm commandlinetools.zip
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+
+      - name: Set up Android SDK and install platform-tools
+        run: |
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | ${SDKMANAGER} "platform-tools"
+
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
       # and we store its JAVA_HOME
       - name: Set up Java 7
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 7
 
@@ -30,7 +47,7 @@ jobs:
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
 
       - name: Set up Java 17 (needed for Spring Boot 3)
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 17
 
@@ -39,7 +56,7 @@ jobs:
 
       # This is the JDK that'll run the build
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
 
@@ -53,17 +70,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-${{ matrix.java }}-
 
-      # Set up Android SDK and install platform-tools
-      - name: Set up Android SDK
-        run: |
-          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
-          echo "y" | ${SDKMANAGER} "platform-tools"
-
       - name: Environment info
         run: |
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
-          ${SDKMANAGER} --version
+          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
           echo JAVA_HOME: ${JAVA_HOME}
           java -version
           javac -version
@@ -91,7 +102,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Java 7
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 7
 
@@ -99,7 +110,7 @@ jobs:
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
 
       - name: Set up Java 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-4333796_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
+          yes | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --update
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 9862592
+          cmdline-tools-version: 9477386
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6825553_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 
@@ -69,7 +69,7 @@ jobs:
           echo JAVA_HOME: ${JAVA_HOME}
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
-          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --version
+          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
 
       - name: Build
         run: 'source ~/.jdk7_home && ./gradlew clean build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,8 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
-          if test "$GITHUB_REPOSITORY" = "rollbar/rollbar-java" -a "$GITHUB_BASE_REF" = ""; then
-            openssl enc -aes-256-cbc -K "$SECRING_GPG_KEY" -iv "$SECRING_GPG_IV" -in "$ENCRYPTED_GPG_KEY_LOCATION" -out "$GPG_KEY_LOCATION" -d
-          fi &&
+          openssl enc -aes-256-cbc -K "$SECRING_GPG_KEY" -iv "$SECRING_GPG_IV" -in "$ENCRYPTED_GPG_KEY_LOCATION" -out "$GPG_KEY_LOCATION" -d
+          &&
           source ~/.jdk7_home &&
           ./.github/release.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 9477386
+          cmdline-tools-version: 10406996
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
+          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
@@ -67,7 +68,7 @@ jobs:
           echo JAVA_HOME: ${JAVA_HOME}
           ./gradlew --version
           echo ANDROID_SDK_ROOT: ${ANDROID_SDK_ROOT}
-          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --version
+          
 
       - name: Build
         run: 'source ~/.jdk7_home && ./gradlew clean build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: ./.github/fetch_to_tag.sh
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f
 
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
         run: ./.github/fetch_to_tag.sh
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 8512546
 
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Java ${{ matrix.java }}
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Capture JDK8_HOME and set it to SDK manager
         run: | 
           echo "export JDK8_HOME=\"$JAVA_HOME\"" > ~/.jdk8_home
-          sed -i "2i export JAVA_HOME=${JDK8_HOME}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
+          sed -i "2i export JAVA_HOME=${JAVA_HOME}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
 
       - name: Set up Java 17 (needed for Spring Boot 3)
         uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,27 @@ jobs:
       - name: Fetch git tags
         run: ./.github/fetch_to_tag.sh
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+      # Download and set up an older version of the Android Command Line Tools
+      - name: Download Android Command Line Tools (older version)
+        run: |
+          wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O commandlinetools.zip
+          unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
+          rm commandlinetools.zip
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
         with:
-          cmdline-tools-version: 9477386
+          java-version: 8
 
+      - name: Capture JDK8_HOME and set it to SDK manager
+        run: |
+          echo "export JDK8_HOME=\"$JAVA_HOME\"" > ~/.jdk8_home
+          sed -i "2i export JAVA_HOME=${JAVA_HOME}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
 
+      - name: Set up Android SDK and install platform-tools
+        run: |
+          echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --licenses
+          echo "y" | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "platform-tools"
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us
@@ -35,16 +50,6 @@ jobs:
 
       - name: Capture JDK7_HOME
         run: echo "export JDK7_HOME=\"$JAVA_HOME\"" > ~/.jdk7_home
-
-      - name: Set up Java 8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-
-      - name: Capture JDK8_HOME and set it to SDK manager
-        run: | 
-          echo "export JDK8_HOME=\"$JAVA_HOME\"" > ~/.jdk8_home
-          sed -i "2i export JAVA_HOME=${JAVA_HOME}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
 
       - name: Set up Java 17 (needed for Spring Boot 3)
         uses: actions/setup-java@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Android SDK 27, 28, 29 and 30
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 9123335
+          cmdline-tools-version: 6858069
       - run: sdkmanager tools "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30"
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-9862592_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
-          ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --install "platform-tools"
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully
       # compatible with Java 7, so we let this action set Java 7 up for us

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Java ${{ matrix.java }}
     strategy:
       matrix:
-        java: [8]
+        java: [8, 11]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Download and set up an older version of the Android Command Line Tools
       - name: Download Android Command Line Tools (older version)
         run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O commandlinetools.zip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
           unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
           rm commandlinetools.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,8 @@ jobs:
       - name: Fetch git tags
         run: ./.github/fetch_to_tag.sh
 
-      # Download and set up an older version of the Android Command Line Tools
-      - name: Download Android Command Line Tools (older version)
-        run: |
-          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O commandlinetools.zip
-          unzip commandlinetools.zip -d ${ANDROID_SDK_ROOT}
-          rm commandlinetools.zip
-          yes | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager --update
-
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
 
       # Our build uses JDK7's rt.jar to make sure the artifact is fully

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ jobs:
         run: ./.github/fetch_to_tag.sh
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-        with:
-          cmdline-tools-version: 9477386
+        run: |
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platforms;android-27" "build-tools;28.0.3"
 
       - name: Set up Java 8
         uses: actions/setup-java@v1


### PR DESCRIPTION
## Description of the change

Old android SDK versions where removed from the runners in [this](https://github.com/actions/runner-images/pull/9094) PR, more info [here](https://github.com/actions/runner-images/issues/8952).

To fix CI I'm adding the command line tools version 9.0 with [this](https://github.com/android-actions/setup-android) action, and setting the SDK manager to use Java 8 because it is incompatible with Java 11, as it was previously here
![Captura de pantalla 2024-08-03 a la(s) 11 49 27 p  m](https://github.com/user-attachments/assets/48da9be4-5db7-4164-9a69-4ff09e0db2d8)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Maintenance
- [ ] New release

## Related issues

- https://github.com/actions/runner-images/issues/8952
- https://github.com/actions/runner-images/pull/9094

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
