### PR TITLE
[Feat][SDK-348] Add uncaught exception to payload

### DIFF
--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/Data.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/Data.java
@@ -309,6 +309,8 @@ public class Data implements JsonSerializable, StringTruncatable<Data> {
       values.put("notifier", notifier);
     }
 
+    values.put("is_uncaught", isUncaught);
+
     return values;
   }
 

--- a/rollbar-api/src/test/java/com/rollbar/api/payload/data/DataTest.java
+++ b/rollbar-api/src/test/java/com/rollbar/api/payload/data/DataTest.java
@@ -80,6 +80,8 @@ public class DataTest {
       expected.put("notifier", data.getNotifier());
     }
 
+    expected.put("is_uncaught", data.isUncaught());
+    
     assertThat(data.asJson(), is(expected));
   }
 }


### PR DESCRIPTION
## Description of the change

- Add `is_uncaught` field to the payload, so that the frontend differentiate between errors not caught by the user

New Payload example:
```
{
  "body": {
    "message": {
      "body": "An error caught by user"
    }
  },
  "is_uncaught": false,
  "uuid": "4f12a62118004563932257b40e9beed7",
  "language": "java",
  "level": "error",
  "timestamp": 1724033268,
  "environment": "production",
  "framework": "android",
  "client": {
    "name_version": "1.0",
    "timestamp": 1724033255,
    "code_version": 1,
    "version_code": 1,
    "user_ip": "123.456.789.123",
    "version_name": "1.0",
    "android": {
      "phone_model": "sdk_gphone64_arm64",
      "version_name": "1.0",
      "android_version": "14",
      "version_code": 1,
      "code_version": "1.0"
    }
  },
  "platform": "android",
  "notifier": {
    "version": "1.10.2-SNAPSHOT",
    "name": "rollbar-android"
  },
  "retentionDays": 180,
  "metadata": {
    "customer_timestamp": 1724033255.191
  }
}
```
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
