### PR TITLE
[Feat][SDK- 431] Add threads information to payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ on:
 jobs:
   validation:
     name: Gradle wrapper validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v3
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build with Java ${{ matrix.java }}
     needs: [ validation ]
     strategy:
@@ -71,7 +71,7 @@ jobs:
             **/build/reports/*
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Release
     # It would be nice to run this as part of the build job, since it would be
     # faster and have less duplicated Yaml, it would not be possible to check

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -33,3 +33,15 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method int com.rollbar.notifier.config.CommonConfig::maximumTelemetryData()"
       justification: "This is going to be added in a major version"
+  "2.1.0":
+    com.rollbar:rollbar-java:
+      - code: "java.method.addedToInterface"
+        new: "method java.util.Map<java.lang.Thread, java.lang.StackTraceElement[]> com.rollbar.notifier.wrapper.ThrowableWrapper::getAllStackTraces()"
+        justification: "This is a binary compatible change, which could only break custom\
+        \ implementations of our config interfaces, but those interfaces are not meant\
+        \ to be implemented by users"
+      - code: "java.method.addedToInterface"
+        new: "method java.lang.Thread com.rollbar.notifier.wrapper.ThrowableWrapper::getThread()"
+        justification: "This is a binary compatible change, which could only break custom\
+        \ implementations of our config interfaces, but those interfaces are not meant\
+        \ to be implemented by users"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -41,7 +41,7 @@ acceptedBreaks:
         \ implementations of our config interfaces, but those interfaces are not meant\
         \ to be implemented by users"
       - code: "java.method.addedToInterface"
-        new: "method java.lang.Thread com.rollbar.notifier.wrapper.ThrowableWrapper::getThread()"
+        new: "method com.rollbar.api.payload.data.body.RollbarThread com.rollbar.notifier.wrapper.ThrowableWrapper::getRollbarThread()"
         justification: "This is a binary compatible change, which could only break custom\
         \ implementations of our config interfaces, but those interfaces are not meant\
         \ to be implemented by users"

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/TelemetryEvent.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/TelemetryEvent.java
@@ -30,11 +30,11 @@ public class TelemetryEvent implements JsonSerializable, StringTruncatable<Telem
    * @param body          a map containing all the data required by the {@link TelemetryType}
    */
   public TelemetryEvent(
-      TelemetryType telemetryType,
-      Level level,
-      Long timestamp,
-      Source source,
-      Map<String, String> body
+    TelemetryType telemetryType,
+    Level level,
+    Long timestamp,
+    Source source,
+    Map<String, String> body
   ) {
     type = telemetryType;
     this.timestamp = timestamp;
@@ -56,29 +56,24 @@ public class TelemetryEvent implements JsonSerializable, StringTruncatable<Telem
 
   @Override
   public TelemetryEvent truncateStrings(int maxLength) {
-    Map<String, String> truncatedMap = new HashMap<>();
-    for (Map.Entry<String, String> entry : body.entrySet()) {
-      String truncatedValue = TruncationHelper.truncateString(entry.getValue(), maxLength);
-      truncatedMap.put(entry.getKey(), truncatedValue);
-    }
     return new TelemetryEvent(
-        this.type,
-        this.level,
-        this.timestamp,
-        this.source,
-        truncatedMap
+      this.type,
+      this.level,
+      this.timestamp,
+      this.source,
+      TruncationHelper.truncateStringsInStringMap(body, maxLength)
     );
   }
 
   @Override
   public String toString() {
     return "TelemetryEvent{"
-        + "type='" + type.asJson() + '\''
-        + ", level='" + level.asJson() + '\''
-        + ", source='" + source + '\''
-        + ", timestamp_ms=" + timestamp
-        + ", body=" + body
-        + '}';
+      + "type='" + type.asJson() + '\''
+      + ", level='" + level.asJson() + '\''
+      + ", source='" + source + '\''
+      + ", timestamp_ms=" + timestamp
+      + ", body=" + body
+      + '}';
   }
 
   @Override
@@ -91,7 +86,7 @@ public class TelemetryEvent implements JsonSerializable, StringTruncatable<Telem
     }
     TelemetryEvent that = (TelemetryEvent) o;
     return type == that.type && level == that.level && Objects.equals(timestamp, that.timestamp)
-        && Objects.equals(body, that.body) && Objects.equals(source, that.source);
+      && Objects.equals(body, that.body) && Objects.equals(source, that.source);
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/TelemetryEvent.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/TelemetryEvent.java
@@ -30,11 +30,11 @@ public class TelemetryEvent implements JsonSerializable, StringTruncatable<Telem
    * @param body          a map containing all the data required by the {@link TelemetryType}
    */
   public TelemetryEvent(
-    TelemetryType telemetryType,
-    Level level,
-    Long timestamp,
-    Source source,
-    Map<String, String> body
+      TelemetryType telemetryType,
+      Level level,
+      Long timestamp,
+      Source source,
+      Map<String, String> body
   ) {
     type = telemetryType;
     this.timestamp = timestamp;
@@ -57,23 +57,23 @@ public class TelemetryEvent implements JsonSerializable, StringTruncatable<Telem
   @Override
   public TelemetryEvent truncateStrings(int maxLength) {
     return new TelemetryEvent(
-      this.type,
-      this.level,
-      this.timestamp,
-      this.source,
-      TruncationHelper.truncateStringsInStringMap(body, maxLength)
+        this.type,
+        this.level,
+        this.timestamp,
+        this.source,
+        TruncationHelper.truncateStringsInStringMap(body, maxLength)
     );
   }
 
   @Override
   public String toString() {
     return "TelemetryEvent{"
-      + "type='" + type.asJson() + '\''
-      + ", level='" + level.asJson() + '\''
-      + ", source='" + source + '\''
-      + ", timestamp_ms=" + timestamp
-      + ", body=" + body
-      + '}';
+        + "type='" + type.asJson() + '\''
+        + ", level='" + level.asJson() + '\''
+        + ", source='" + source + '\''
+        + ", timestamp_ms=" + timestamp
+        + ", body=" + body
+        + '}';
   }
 
   @Override
@@ -86,7 +86,7 @@ public class TelemetryEvent implements JsonSerializable, StringTruncatable<Telem
     }
     TelemetryEvent that = (TelemetryEvent) o;
     return type == that.type && level == that.level && Objects.equals(timestamp, that.timestamp)
-      && Objects.equals(body, that.body) && Objects.equals(source, that.source);
+        && Objects.equals(body, that.body) && Objects.equals(source, that.source);
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -4,9 +4,7 @@ import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.payload.data.TelemetryEvent;
 import com.rollbar.api.truncation.StringTruncatable;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * A container for the actual error(s), message, or crash report that caused this error.
@@ -29,6 +27,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
   /**
    * Getter.
+   *
    * @return the contents.
    */
   public BodyContent getContents() {
@@ -58,8 +57,9 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
   public Body truncateStrings(int maxSize) {
     if (bodyContent != null) {
       return new Body.Builder(this)
-          .bodyContent(bodyContent.truncateStrings(maxSize))
-          .build();
+        .bodyContent(bodyContent.truncateStrings(maxSize))
+        .telemetryEvents(truncatedTelemetryEvents(maxSize))
+        .build();
     } else {
       return this;
     }
@@ -77,7 +77,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
     Body body = (Body) o;
     return Objects.equals(bodyContent, body.bodyContent)
-        && Objects.equals(telemetryEvents, body.telemetryEvents);
+      && Objects.equals(telemetryEvents, body.telemetryEvents);
   }
 
   @Override
@@ -88,10 +88,22 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
   @Override
   public String toString() {
     return "Body{"
-        + "bodyContent=" + bodyContent
-        + ", telemetry=" + telemetryEvents
-        + ", group=" + groups
-        + '}';
+      + "bodyContent=" + bodyContent
+      + ", telemetry=" + telemetryEvents
+      + ", group=" + groups
+      + '}';
+  }
+
+  private List<TelemetryEvent> truncatedTelemetryEvents(int maxSize) {
+    if (telemetryEvents == null) {
+      return null;
+    }
+
+    List<TelemetryEvent> truncatedTelemetryEvents = new ArrayList<>();
+    for (TelemetryEvent telemetryEvent : telemetryEvents) {
+      truncatedTelemetryEvents.add(telemetryEvent.truncateStrings(maxSize));
+    }
+    return truncatedTelemetryEvents;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -3,6 +3,7 @@ package com.rollbar.api.payload.data.body;
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.payload.data.TelemetryEvent;
 import com.rollbar.api.truncation.StringTruncatable;
+import com.rollbar.api.truncation.TruncationHelper;
 
 import java.util.*;
 
@@ -58,7 +59,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     if (bodyContent != null) {
       return new Body.Builder(this)
         .bodyContent(bodyContent.truncateStrings(maxSize))
-        .telemetryEvents(truncatedTelemetryEvents(maxSize))
+        .telemetryEvents(TruncationHelper.truncate(telemetryEvents, maxSize))
         .build();
     } else {
       return this;
@@ -92,18 +93,6 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
       + ", telemetry=" + telemetryEvents
       + ", group=" + groups
       + '}';
-  }
-
-  private List<TelemetryEvent> truncatedTelemetryEvents(int maxSize) {
-    if (telemetryEvents == null) {
-      return null;
-    }
-
-    List<TelemetryEvent> truncatedTelemetryEvents = new ArrayList<>();
-    for (TelemetryEvent telemetryEvent : telemetryEvents) {
-      truncatedTelemetryEvents.add(telemetryEvent.truncateStrings(maxSize));
-    }
-    return truncatedTelemetryEvents;
   }
 
   /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -6,8 +6,8 @@ import com.rollbar.api.truncation.StringTruncatable;
 import com.rollbar.api.truncation.TruncationHelper;
 
 import java.util.HashMap;
-import java.util.Objects;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A container for the actual error(s), message, or crash report that caused this error.

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -60,6 +60,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
       return new Body.Builder(this)
         .bodyContent(bodyContent.truncateStrings(maxSize))
         .telemetryEvents(TruncationHelper.truncate(telemetryEvents, maxSize))
+        .groups(TruncationHelper.truncate(groups, maxSize))
         .build();
     } else {
       return this;

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -19,12 +19,12 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
   private final List<TelemetryEvent> telemetryEvents;
 
-  private final List<RollbarThread> rollbarThreads;
+  private final List<Group> groups;
 
   private Body(Builder builder) {
     this.bodyContent = builder.bodyContent;
     this.telemetryEvents = builder.telemetryEvents;
-    this.rollbarThreads = builder.rollbarThreads;
+    this.groups = builder.groups;
   }
 
   /**
@@ -47,8 +47,8 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
       values.put("telemetry", telemetryEvents);
     }
 
-    if (rollbarThreads != null) {
-      values.put("threads", rollbarThreads);
+    if (groups != null) {
+      values.put("group", groups);
     }
 
     return values;
@@ -90,7 +90,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     return "Body{"
         + "bodyContent=" + bodyContent
         + ", telemetry=" + telemetryEvents
-        + ", threads=" + rollbarThreads
+        + ", group=" + groups
         + '}';
   }
 
@@ -103,7 +103,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
     private List<TelemetryEvent> telemetryEvents;
 
-    private List<RollbarThread> rollbarThreads;
+    private List<Group> groups;
 
     /**
      * Constructor.
@@ -120,7 +120,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     public Builder(Body body) {
       bodyContent = body.bodyContent;
       telemetryEvents = body.telemetryEvents;
-      rollbarThreads = body.rollbarThreads;
+      groups = body.groups;
     }
 
     /**
@@ -147,13 +147,13 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     }
 
     /**
-     * Information from other threads.
+     * Information from a group of threads.
      *
-     * @param rollbarThreads a list of threads without the thread where the Exception occurred;
+     * @param groups a group with a list of threads;
      * @return the builder instance.
      */
-    public Builder rollbarThreads(List<RollbarThread> rollbarThreads) {
-      this.rollbarThreads = rollbarThreads;
+    public Builder groups(List<Group> groups) {
+      this.groups = groups;
       return this;
     }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -5,7 +5,9 @@ import com.rollbar.api.payload.data.TelemetryEvent;
 import com.rollbar.api.truncation.StringTruncatable;
 import com.rollbar.api.truncation.TruncationHelper;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.List;
 
 /**
  * A container for the actual error(s), message, or crash report that caused this error.

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -46,6 +46,15 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     return rollbarThreads;
   }
 
+  /**
+   * Getter.
+   *
+   * @return the list of Telemetry events.
+   */
+  public List<TelemetryEvent> getTelemetryEvents() {
+    return telemetryEvents;
+  }
+
   @Override
   public Object asJson() {
     HashMap<String, Object> values = new HashMap<>();

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -37,6 +37,15 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     return bodyContent;
   }
 
+  /**
+   * Getter.
+   *
+   * @return the rollbar threads.
+   */
+  public List<RollbarThread> getRollbarThreads() {
+    return rollbarThreads;
+  }
+
   @Override
   public Object asJson() {
     HashMap<String, Object> values = new HashMap<>();
@@ -81,12 +90,13 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
     Body body = (Body) o;
     return Objects.equals(bodyContent, body.bodyContent)
-      && Objects.equals(telemetryEvents, body.telemetryEvents);
+      && Objects.equals(telemetryEvents, body.telemetryEvents)
+      && Objects.equals(rollbarThreads, body.rollbarThreads);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bodyContent, telemetryEvents);
+    return Objects.hash(bodyContent, telemetryEvents, rollbarThreads);
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -18,12 +18,12 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
   private final List<TelemetryEvent> telemetryEvents;
 
-  private final List<Group> groups;
+  private final List<RollbarThread> rollbarThreads;
 
   private Body(Builder builder) {
     this.bodyContent = builder.bodyContent;
     this.telemetryEvents = builder.telemetryEvents;
-    this.groups = builder.groups;
+    this.rollbarThreads = builder.rollbarThreads;
   }
 
   /**
@@ -47,8 +47,8 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
       values.put("telemetry", telemetryEvents);
     }
 
-    if (groups != null) {
-      values.put("group", groups);
+    if (rollbarThreads != null) {
+      values.put("threads", rollbarThreads);
     }
 
     return values;
@@ -60,7 +60,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
       return new Body.Builder(this)
         .bodyContent(bodyContent.truncateStrings(maxSize))
         .telemetryEvents(TruncationHelper.truncate(telemetryEvents, maxSize))
-        .groups(TruncationHelper.truncate(groups, maxSize))
+        .rollbarThreads(TruncationHelper.truncate(rollbarThreads, maxSize))
         .build();
     } else {
       return this;
@@ -92,7 +92,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     return "Body{"
       + "bodyContent=" + bodyContent
       + ", telemetry=" + telemetryEvents
-      + ", group=" + groups
+      + ", threads=" + rollbarThreads
       + '}';
   }
 
@@ -105,7 +105,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
     private List<TelemetryEvent> telemetryEvents;
 
-    private List<Group> groups;
+    private List<RollbarThread> rollbarThreads;
 
     /**
      * Constructor.
@@ -122,7 +122,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     public Builder(Body body) {
       bodyContent = body.bodyContent;
       telemetryEvents = body.telemetryEvents;
-      groups = body.groups;
+      rollbarThreads = body.rollbarThreads;
     }
 
     /**
@@ -149,13 +149,13 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     }
 
     /**
-     * Information from a group of threads.
+     * Information from threads.
      *
-     * @param groups a group with a list of threads;
+     * @param rollbarThreads a list of threads;
      * @return the builder instance.
      */
-    public Builder groups(List<Group> groups) {
-      this.groups = groups;
+    public Builder rollbarThreads(List<RollbarThread> rollbarThreads) {
+      this.rollbarThreads = rollbarThreads;
       return this;
     }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Body.java
@@ -19,9 +19,12 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
   private final List<TelemetryEvent> telemetryEvents;
 
+  private final List<RollbarThread> rollbarThreads;
+
   private Body(Builder builder) {
     this.bodyContent = builder.bodyContent;
     this.telemetryEvents = builder.telemetryEvents;
+    this.rollbarThreads = builder.rollbarThreads;
   }
 
   /**
@@ -42,6 +45,10 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
 
     if (telemetryEvents != null) {
       values.put("telemetry", telemetryEvents);
+    }
+
+    if (rollbarThreads != null) {
+      values.put("threads", rollbarThreads);
     }
 
     return values;
@@ -83,6 +90,7 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     return "Body{"
         + "bodyContent=" + bodyContent
         + ", telemetry=" + telemetryEvents
+        + ", threads=" + rollbarThreads
         + '}';
   }
 
@@ -94,6 +102,8 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
     private BodyContent bodyContent;
 
     private List<TelemetryEvent> telemetryEvents;
+
+    private List<RollbarThread> rollbarThreads;
 
     /**
      * Constructor.
@@ -108,8 +118,9 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
      * @param body the {@link Body body} to initialize a new builder instance.
      */
     public Builder(Body body) {
-      this.bodyContent = body.bodyContent;
-      this.telemetryEvents = body.telemetryEvents;
+      bodyContent = body.bodyContent;
+      telemetryEvents = body.telemetryEvents;
+      rollbarThreads = body.rollbarThreads;
     }
 
     /**
@@ -132,6 +143,17 @@ public class Body implements JsonSerializable, StringTruncatable<Body> {
      */
     public Builder telemetryEvents(List<TelemetryEvent> telemetryEvents) {
       this.telemetryEvents = telemetryEvents;
+      return this;
+    }
+
+    /**
+     * Information from other threads.
+     *
+     * @param rollbarThreads a list of threads without the thread where the Exception occurred;
+     * @return the builder instance.
+     */
+    public Builder rollbarThreads(List<RollbarThread> rollbarThreads) {
+      this.rollbarThreads = rollbarThreads;
       return this;
     }
 

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -55,4 +55,11 @@ public class Group implements JsonSerializable, StringTruncatable<Group> {
   public int hashCode() {
     return Objects.hashCode(traceChain);
   }
+
+  @Override
+  public String toString() {
+    return "Group{" +
+        "traceChain=" + traceChain +
+        '}';
+  }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -2,9 +2,11 @@ package com.rollbar.api.payload.data.body;
 
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.truncation.StringTruncatable;
+import com.rollbar.api.truncation.TruncationHelper;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 public class Group implements JsonSerializable, StringTruncatable<Group> {
   private final List<RollbarThread> rollbarThreads;
@@ -26,6 +28,18 @@ public class Group implements JsonSerializable, StringTruncatable<Group> {
 
   @Override
   public Group truncateStrings(int maxLength) {
-    return null;
+    return new Group(TruncationHelper.truncate(rollbarThreads, maxLength));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Group)) return false;
+    Group group = (Group) o;
+    return Objects.equals(rollbarThreads, group.rollbarThreads);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(rollbarThreads);
   }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -13,10 +13,19 @@ import java.util.Objects;
  * JS (AggregatorError), it may be more TraceChains per group.
  */
 public class Group implements JsonSerializable, StringTruncatable<Group> {
-  private final BodyContent traceChain;
+  private final TraceChain traceChain;
 
-  public Group(BodyContent traceChain) {
+  public Group(TraceChain traceChain) {
     this.traceChain = traceChain;
+  }
+
+  /**
+   * Getter.
+   *
+   * @return the trace chain.
+   */
+  public TraceChain getTraceChain() {
+    return traceChain;
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -1,0 +1,31 @@
+package com.rollbar.api.payload.data.body;
+
+import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class Group implements JsonSerializable, StringTruncatable<Group> {
+  private final List<RollbarThread> rollbarThreads;
+
+  public Group(List<RollbarThread> threads) {
+    rollbarThreads = threads;
+  }
+
+  @Override
+  public Object asJson() {
+    HashMap<String, Object> values = new HashMap<>();
+
+    if (rollbarThreads != null) {
+      values.put("threads", rollbarThreads);
+    }
+
+    return values;
+  }
+
+  @Override
+  public Group truncateStrings(int maxLength) {
+    return null;
+  }
+}

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -58,8 +58,6 @@ public class Group implements JsonSerializable, StringTruncatable<Group> {
 
   @Override
   public String toString() {
-    return "Group{" +
-        "traceChain=" + traceChain +
-        '}';
+    return "Group{traceChain=" + traceChain + '}';
   }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -2,44 +2,41 @@ package com.rollbar.api.payload.data.body;
 
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.truncation.StringTruncatable;
-import com.rollbar.api.truncation.TruncationHelper;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 
 public class Group implements JsonSerializable, StringTruncatable<Group> {
-  private final List<RollbarThread> rollbarThreads;
+  private final BodyContent traceChain;
 
-  public Group(List<RollbarThread> threads) {
-    rollbarThreads = threads;
+  public Group(BodyContent traceChain) {
+    this.traceChain = traceChain;
   }
 
   @Override
   public Object asJson() {
     HashMap<String, Object> values = new HashMap<>();
-
-    if (rollbarThreads != null) {
-      values.put("threads", rollbarThreads);
-    }
-
-    return values;
+    values.put("trace_chain", traceChain);
+    ArrayList<HashMap<String, Object>> traceChains = new ArrayList<>();
+    traceChains.add(values);
+    return traceChains;
   }
 
   @Override
   public Group truncateStrings(int maxLength) {
-    return new Group(TruncationHelper.truncate(rollbarThreads, maxLength));
+    return new Group(traceChain.truncateStrings(maxLength));
   }
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Group)) return false;
+    if (o == null || getClass() != o.getClass()) return false;
     Group group = (Group) o;
-    return Objects.equals(rollbarThreads, group.rollbarThreads);
+    return Objects.equals(traceChain, group.traceChain);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(rollbarThreads);
+    return Objects.hashCode(traceChain);
   }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/Group.java
@@ -7,6 +7,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
 
+/**
+ * This represent a Group of trace chains in a Thread.
+ * In Java we only send 1 TraceChain per Group, in other languages like Python (ExceptionGroup) or
+ * JS (AggregatorError), it may be more TraceChains per group.
+ */
 public class Group implements JsonSerializable, StringTruncatable<Group> {
   private final BodyContent traceChain;
 
@@ -30,7 +35,9 @@ public class Group implements JsonSerializable, StringTruncatable<Group> {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) return false;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     Group group = (Group) o;
     return Objects.equals(traceChain, group.traceChain);
   }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -8,28 +8,21 @@ import java.util.Map;
 import java.util.Objects;
 
 public class RollbarThread implements JsonSerializable, StringTruncatable<RollbarThread> {
-
-  private final String name;
-  private final String id;
-  private final String priority;
-  private final String state;
+  private final Thread thread;
   private final BodyContent bodyContent;
 
   public RollbarThread(Thread thread, BodyContent bodyContent) {
-    name = thread.getName();
-    id = String.valueOf(thread.getId());
-    priority = String.valueOf(thread.getPriority());
-    state = thread.getState().toString();
+    this.thread = thread;
     this.bodyContent = bodyContent;
   }
 
   @Override
   public Object asJson() {
     Map<String, Object> values = new HashMap<>();
-    values.put("name", name);
-    values.put("id", id);
-    values.put("priority", priority);
-    values.put("state", state);
+    values.put("name", getThreadName());
+    values.put("id", getThreadId());
+    values.put("priority", getThreadPriority());
+    values.put("state", getThreadState());
     if (bodyContent != null) {
       values.put(bodyContent.getKeyName(), bodyContent);
     }
@@ -38,36 +31,45 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
 
   @Override
   public RollbarThread truncateStrings(int maxLength) {
-    return null;
+    return new RollbarThread(thread, bodyContent.truncateStrings(maxLength));
   }
 
   @Override
   public String toString() {
     return "RollbarThread{" +
-      "name='" + name + '\'' +
-      ", id='" + id + '\'' +
-      ", priority='" + priority + '\'' +
-      ", state='" + state + '\'' +
+      "name='" + getThreadName() + '\'' +
+      ", id='" + getThreadId() + '\'' +
+      ", priority='" + getThreadPriority() + '\'' +
+      ", state='" + getThreadState() + '\'' +
       ", " + bodyContent.getKeyName() + "=" + bodyContent +
       '}';
+  }
+
+  private String getThreadName() {
+    return thread.getName();
+  }
+
+  private String getThreadId() {
+    return String.valueOf(thread.getId());
+  }
+
+  private String getThreadPriority() {
+    return  String.valueOf(thread.getPriority());
+  }
+
+  private String getThreadState() {
+    return thread.getState().toString();
   }
 
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof RollbarThread)) return false;
     RollbarThread that = (RollbarThread) o;
-    return Objects.equals(name, that.name) && Objects.equals(id, that.id) && Objects.equals(priority, that.priority) && Objects.equals(state, that.state) && Objects.equals(bodyContent, that.bodyContent);
+    return Objects.equals(thread, that.thread) && Objects.equals(bodyContent, that.bodyContent);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id, priority, state, bodyContent);
-  }
-
-  /**
-   * Builder class for {@link RollbarThread RollbarThread}.
-   */
-  public static final class Builder {
-
+    return Objects.hash(thread, bodyContent);
   }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -154,7 +154,8 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
     /**
      * Constructor.
      *
-     * @param rollbarThread the {@link RollbarThread rollbarThread} to initialize a new builder instance.
+     * @param rollbarThread the {@link RollbarThread rollbarThread} to initialize
+     *                      a new builder instance.
      */
     public Builder(RollbarThread rollbarThread) {
       name = rollbarThread.name;

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -151,6 +151,11 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
     private String state;
     private Group group;
 
+    /**
+     * Constructor.
+     *
+     * @param rollbarThread the {@link RollbarThread rollbarThread} to initialize a new builder instance.
+     */
     public Builder(RollbarThread rollbarThread) {
       name = rollbarThread.name;
       id = rollbarThread.id;

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -44,6 +44,51 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
     this.group = group;
   }
 
+  /**
+   * Getter
+   *
+   * @return the group for this Thread
+   */
+  public Group getGroup() {
+    return group;
+  }
+
+  /**
+   * Getter
+   *
+   * @return the state of this Thread
+   */
+  public String getState() {
+    return state;
+  }
+
+  /**
+   * Getter
+   *
+   * @return the priority of this Thread
+   */
+  public String getPriority() {
+    return priority;
+  }
+
+  /**
+   * Getter
+   *
+   * @return the id of this Thread
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Getter
+   *
+   * @return the name of this Thread
+   */
+  public String getName() {
+    return name;
+  }
+
   @Override
   public Object asJson() {
     Map<String, Object> values = new HashMap<>();
@@ -94,5 +139,50 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
   @Override
   public int hashCode() {
     return Objects.hash(name, id, priority, state, group);
+  }
+
+  /**
+   * Builder class for {@link RollbarThread RollbarThread}.
+   */
+  public static final class Builder {
+    private String name;
+    private String id;
+    private String priority;
+    private String state;
+    private Group group;
+
+    public Builder(RollbarThread rollbarThread) {
+      name = rollbarThread.name;
+      id = rollbarThread.id;
+      priority = rollbarThread.priority;
+      state = rollbarThread.state;
+      group = rollbarThread.group;
+    }
+
+    /**
+     * The group for this thread.
+     *
+     * @param group an updated version of group;
+     * @return the builder instance.
+     */
+    public Builder group(Group group) {
+      this.group = group;
+      return this;
+    }
+
+    /**
+     * Builds the {@link RollbarThread RollbarThread}.
+     *
+     * @return the RollbarThread.
+     */
+    public RollbarThread build() {
+      return new RollbarThread(
+        name,
+        id,
+        priority,
+        state,
+        group
+      );
+    }
   }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -15,6 +15,7 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
   private final String id;
   private final String priority;
   private final String state;
+  private final boolean isMain;
   private final Group group;
 
   /**
@@ -27,6 +28,7 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
     id = String.valueOf(thread.getId());
     priority = String.valueOf(thread.getPriority());
     state = thread.getState().toString();
+    isMain = isMain(thread.getName());
     this.group = group;
   }
 
@@ -37,6 +39,7 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
       String state,
       Group group
   ) {
+    isMain = isMain(name);
     this.name = name;
     this.id = id;
     this.priority = priority;
@@ -96,6 +99,7 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
     values.put("id", id);
     values.put("priority", priority);
     values.put("state", state);
+    values.put("is_main", isMain);
     values.put("group", group);
     return values;
   }
@@ -118,6 +122,7 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
         + ", id='" + id + '\''
         + ", priority='" + priority + '\''
         + ", state='" + state + '\''
+        + ", isMain='" + isMain + '\''
         + ", group='" + group
         + '}';
   }
@@ -133,22 +138,27 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
         && Objects.equals(id, that.id)
         && Objects.equals(priority, that.priority)
         && Objects.equals(state, that.state)
+        && Objects.equals(isMain, that.isMain)
         && Objects.equals(group, that.group);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, id, priority, state, group);
+    return Objects.hash(name, id, priority, state, isMain, group);
+  }
+
+  private boolean isMain(String string) {
+    return "main".equals(string);
   }
 
   /**
    * Builder class for {@link RollbarThread RollbarThread}.
    */
   public static final class Builder {
-    private String name;
-    private String id;
-    private String priority;
-    private String state;
+    private final String name;
+    private final String id;
+    private final String priority;
+    private final String state;
     private Group group;
 
     /**

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -2,13 +2,14 @@ package com.rollbar.api.payload.data.body;
 
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.truncation.StringTruncatable;
-import com.rollbar.api.truncation.TruncationHelper;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Represents Thread information
+ */
 public class RollbarThread implements JsonSerializable, StringTruncatable<RollbarThread> {
   private final String name;
   private final String id;
@@ -62,21 +63,27 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
 
   @Override
   public String toString() {
-    return "RollbarThread{" +
-        "name='" + name + '\'' +
-        ", id='" + id + '\'' +
-        ", priority='" + priority + '\'' +
-        ", state='" + state + '\'' +
-        ", group='" + group +
-        '}';
+    return "RollbarThread{"
+        + "name='" + name + '\''
+        + ", id='" + id + '\''
+        + ", priority='" + priority + '\''
+        + ", state='" + state + '\''
+        + ", group='" + group
+        + '}';
   }
 
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) return false;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     RollbarThread that = (RollbarThread) o;
-    return Objects.equals(name, that.name) && Objects.equals(id, that.id) && Objects.equals(priority, that.priority) && Objects.equals(state, that.state) && Objects.equals(group, that.group);
+    return Objects.equals(name, that.name)
+        && Objects.equals(id, that.id)
+        && Objects.equals(priority, that.priority)
+        && Objects.equals(state, that.state)
+        && Objects.equals(group, that.group);
   }
 
   @Override

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -45,45 +45,45 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
   }
 
   /**
-   * Getter
+   * Getter.
    *
-   * @return the group for this Thread
+   * @return the group for this Thread.
    */
   public Group getGroup() {
     return group;
   }
 
   /**
-   * Getter
+   * Getter.
    *
-   * @return the state of this Thread
+   * @return the state of this Thread.
    */
   public String getState() {
     return state;
   }
 
   /**
-   * Getter
+   * Getter.
    *
-   * @return the priority of this Thread
+   * @return the priority of this Thread.
    */
   public String getPriority() {
     return priority;
   }
 
   /**
-   * Getter
+   * Getter.
    *
-   * @return the id of this Thread
+   * @return the id of this Thread.
    */
   public String getId() {
     return id;
   }
 
   /**
-   * Getter
+   * Getter.
    *
-   * @return the name of this Thread
+   * @return the name of this Thread.
    */
   public String getName() {
     return name;

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -1,0 +1,73 @@
+package com.rollbar.api.payload.data.body;
+
+import com.rollbar.api.json.JsonSerializable;
+import com.rollbar.api.truncation.StringTruncatable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class RollbarThread implements JsonSerializable, StringTruncatable<RollbarThread> {
+
+  private final String name;
+  private final String id;
+  private final String priority;
+  private final String state;
+  private final BodyContent bodyContent;
+
+  public RollbarThread(Thread thread, BodyContent bodyContent) {
+    name = thread.getName();
+    id = String.valueOf(thread.getId());
+    priority = String.valueOf(thread.getPriority());
+    state = thread.getState().toString();
+    this.bodyContent = bodyContent;
+  }
+
+  @Override
+  public Object asJson() {
+    Map<String, Object> values = new HashMap<>();
+    values.put("name", name);
+    values.put("id", id);
+    values.put("priority", priority);
+    values.put("state", state);
+    if (bodyContent != null) {
+      values.put(bodyContent.getKeyName(), bodyContent);
+    }
+    return values;
+  }
+
+  @Override
+  public RollbarThread truncateStrings(int maxLength) {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "RollbarThread{" +
+      "name='" + name + '\'' +
+      ", id='" + id + '\'' +
+      ", priority='" + priority + '\'' +
+      ", state='" + state + '\'' +
+      ", " + bodyContent.getKeyName() + "=" + bodyContent +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof RollbarThread)) return false;
+    RollbarThread that = (RollbarThread) o;
+    return Objects.equals(name, that.name) && Objects.equals(id, that.id) && Objects.equals(priority, that.priority) && Objects.equals(state, that.state) && Objects.equals(bodyContent, that.bodyContent);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, id, priority, state, bodyContent);
+  }
+
+  /**
+   * Builder class for {@link RollbarThread RollbarThread}.
+   */
+  public static final class Builder {
+
+  }
+}

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Represents Thread information
+ * Represents Thread information.
  */
 public class RollbarThread implements JsonSerializable, StringTruncatable<RollbarThread> {
   private final String name;
@@ -17,6 +17,11 @@ public class RollbarThread implements JsonSerializable, StringTruncatable<Rollba
   private final String state;
   private final Group group;
 
+  /**
+   * Constructor.
+   * @param thread the Thread.
+   * @param group the Group of trace chains.
+   */
   public RollbarThread(Thread thread, Group group) {
     name = thread.getName();
     id = String.valueOf(thread.getId());

--- a/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/payload/data/body/RollbarThread.java
@@ -2,74 +2,85 @@ package com.rollbar.api.payload.data.body;
 
 import com.rollbar.api.json.JsonSerializable;
 import com.rollbar.api.truncation.StringTruncatable;
+import com.rollbar.api.truncation.TruncationHelper;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public class RollbarThread implements JsonSerializable, StringTruncatable<RollbarThread> {
-  private final Thread thread;
-  private final BodyContent bodyContent;
+  private final String name;
+  private final String id;
+  private final String priority;
+  private final String state;
+  private final Group group;
 
-  public RollbarThread(Thread thread, BodyContent bodyContent) {
-    this.thread = thread;
-    this.bodyContent = bodyContent;
+  public RollbarThread(Thread thread, Group group) {
+    name = thread.getName();
+    id = String.valueOf(thread.getId());
+    priority = String.valueOf(thread.getPriority());
+    state = thread.getState().toString();
+    this.group = group;
+  }
+
+  private RollbarThread(
+      String name,
+      String id,
+      String priority,
+      String state,
+      Group group
+  ) {
+    this.name = name;
+    this.id = id;
+    this.priority = priority;
+    this.state = state;
+    this.group = group;
   }
 
   @Override
   public Object asJson() {
     Map<String, Object> values = new HashMap<>();
-    values.put("name", getThreadName());
-    values.put("id", getThreadId());
-    values.put("priority", getThreadPriority());
-    values.put("state", getThreadState());
-    if (bodyContent != null) {
-      values.put(bodyContent.getKeyName(), bodyContent);
-    }
+    values.put("name", name);
+    values.put("id", id);
+    values.put("priority", priority);
+    values.put("state", state);
+    values.put("group", group);
     return values;
   }
 
   @Override
   public RollbarThread truncateStrings(int maxLength) {
-    return new RollbarThread(thread, bodyContent.truncateStrings(maxLength));
+    return new RollbarThread(
+        name,
+        id,
+        priority,
+        state,
+        group.truncateStrings(maxLength)
+    );
   }
 
   @Override
   public String toString() {
     return "RollbarThread{" +
-      "name='" + getThreadName() + '\'' +
-      ", id='" + getThreadId() + '\'' +
-      ", priority='" + getThreadPriority() + '\'' +
-      ", state='" + getThreadState() + '\'' +
-      ", " + bodyContent.getKeyName() + "=" + bodyContent +
-      '}';
+        "name='" + name + '\'' +
+        ", id='" + id + '\'' +
+        ", priority='" + priority + '\'' +
+        ", state='" + state + '\'' +
+        ", group='" + group +
+        '}';
   }
 
-  private String getThreadName() {
-    return thread.getName();
-  }
-
-  private String getThreadId() {
-    return String.valueOf(thread.getId());
-  }
-
-  private String getThreadPriority() {
-    return  String.valueOf(thread.getPriority());
-  }
-
-  private String getThreadState() {
-    return thread.getState().toString();
-  }
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof RollbarThread)) return false;
+    if (o == null || getClass() != o.getClass()) return false;
     RollbarThread that = (RollbarThread) o;
-    return Objects.equals(thread, that.thread) && Objects.equals(bodyContent, that.bodyContent);
+    return Objects.equals(name, that.name) && Objects.equals(id, that.id) && Objects.equals(priority, that.priority) && Objects.equals(state, that.state) && Objects.equals(group, that.group);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(thread, bodyContent);
+    return Objects.hash(name, id, priority, state, group);
   }
 }

--- a/rollbar-api/src/main/java/com/rollbar/api/truncation/TruncationHelper.java
+++ b/rollbar-api/src/main/java/com/rollbar/api/truncation/TruncationHelper.java
@@ -29,6 +29,25 @@ public class TruncationHelper {
   }
 
   /**
+   * Truncates all the StringTruncatable in the list to the specified maximum length.
+   * @param values The StringTruncatables to be truncated.
+   * @param maxLength Maximum length of each string.
+   * @return A list containing the truncated StringTruncatables.
+   */
+  public static <T extends StringTruncatable<T>> List<T> truncate(List<T> values, int maxLength) {
+    if (values == null) {
+      return null;
+    }
+
+    List<T> result = new ArrayList<>(values.size());
+    for (T value : values) {
+      result.add(value.truncateStrings(maxLength));
+    }
+
+    return result;
+  }
+
+  /**
    * Truncates any strings in the list to the specified maximum length.
    * @param values The list of objects which might contain strings to be truncated.
    * @param maxLength Maximum length of each string.

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -553,7 +553,7 @@ public class Rollbar extends RollbarBase<Void, Config> {
   }
 
   /**
-   * Record an error or message with extra data at the level specified. At least ene of `error` or
+   * Record an error or message with extra data at the level specified. At least one of `error` or
    * `description` must be non-null. If error is null, `description` will be sent as a message. If
    * error is non-null, description will be sent as the description of the error. Custom data will
    * be attached to message if the error is null. Custom data will extend whatever {@link
@@ -569,7 +569,7 @@ public class Rollbar extends RollbarBase<Void, Config> {
   }
 
   /**
-   * Record an error or message with extra data at the level specified. At least ene of `error` or
+   * Record an error or message with extra data at the level specified. At least one of `error` or
    * `description` must be non-null. If error is null, `description` will be sent as a message. If
    * error is non-null, description will be sent as the description of the error. Custom data will
    * be attached to message if the error is null. Custom data will extend whatever {@link
@@ -579,7 +579,7 @@ public class Rollbar extends RollbarBase<Void, Config> {
    * @param custom the custom data (if any).
    * @param description the description of the error, or the message to send.
    * @param level the level to send it at.
-   * @param isUncaught whether or not this data comes from an uncaught exception.
+   * @param isUncaught whether this data comes from an uncaught exception.
    */
   public void log(Throwable error, Map<String, Object> custom, String description, Level level,
       boolean isUncaught) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -601,12 +601,12 @@ public class Rollbar extends RollbarBase<Void, Config> {
    * @param isUncaught whether this data comes from an uncaught exception.
    */
   public void log(
-    Throwable error,
-    Thread thread,
-    Map<String, Object> custom,
-    String description,
-    Level level,
-    boolean isUncaught
+      Throwable error,
+      Thread thread,
+      Map<String, Object> custom,
+      String description,
+      Level level,
+      boolean isUncaught
   ) {
     this.log(wrapThrowable(error, thread), custom, description, level, isUncaught);
   }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/Rollbar.java
@@ -587,7 +587,32 @@ public class Rollbar extends RollbarBase<Void, Config> {
   }
 
   /**
-   * Record an error or message with extra data at the level specified. At least ene of `error` or
+   * Record an error or message with extra data at the level specified. At least one of `error` or
+   * `description` must be non-null. If error is null, `description` will be sent as a message. If
+   * error is non-null, description will be sent as the description of the error. Custom data will
+   * be attached to message if the error is null. Custom data will extend whatever {@link
+   * Config#custom} returns.
+   *
+   * @param error the error (if any).
+   * @param thread the thread where the error happened (if any).
+   * @param custom the custom data (if any).
+   * @param description the description of the error, or the message to send.
+   * @param level the level to send it at.
+   * @param isUncaught whether this data comes from an uncaught exception.
+   */
+  public void log(
+    Throwable error,
+    Thread thread,
+    Map<String, Object> custom,
+    String description,
+    Level level,
+    boolean isUncaught
+  ) {
+    this.log(wrapThrowable(error, thread), custom, description, level, isUncaught);
+  }
+
+  /**
+   * Record an error or message with extra data at the level specified. At least one of `error` or
    * `description` must be non-null. If error is null, `description` will be sent as a message. If
    * error is non-null, description will be sent as the description of the error. Custom data will
    * be attached to message if the error is null. Custom data will extend whatever {@link
@@ -597,7 +622,7 @@ public class Rollbar extends RollbarBase<Void, Config> {
    * @param custom the custom data (if any).
    * @param description the description of the error, or the message to send.
    * @param level the level to send it at.
-   * @param isUncaught whether or not this data comes from an uncaught exception.
+   * @param isUncaught whether this data comes from an uncaught exception.
    */
   public void log(ThrowableWrapper error, Map<String, Object> custom, String description,
                   Level level, boolean isUncaught) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/RollbarBase.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/RollbarBase.java
@@ -326,14 +326,20 @@ public abstract class RollbarBase<RESULT, C extends CommonConfig> {
     return payload;
   }
 
-  protected RollbarThrowableWrapper wrapThrowable(Throwable error) {
-    RollbarThrowableWrapper rollbarThrowableWrapper = null;
+  protected RollbarThrowableWrapper wrapThrowable(Throwable error, Thread thread) {
+    if (error != null && thread != null) {
+      return new RollbarThrowableWrapper(error, thread);
+    } else {
+      return wrapThrowable(error);
+    }
+  }
 
-    if (error != null) {
-      rollbarThrowableWrapper = new RollbarThrowableWrapper(error);
+  protected RollbarThrowableWrapper wrapThrowable(Throwable error) {
+    if (error == null) {
+      return null;
     }
 
-    return rollbarThrowableWrapper;
+    return new RollbarThrowableWrapper(error);
   }
 
   protected abstract RESULT sendPayload(C config, Payload payload);

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/FramesStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/FramesStrategy.java
@@ -42,7 +42,7 @@ class FramesStrategy implements TruncationStrategy {
     return TruncationResult.none();
   }
 
-  private TruncationResult<TraceChain> truncateTraceChain(TraceChain chain) {
+  TruncationResult<TraceChain> truncateTraceChain(TraceChain chain) {
     boolean truncated = false;
 
     ArrayList<Trace> updated = new ArrayList<>();

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/PayloadTruncator.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/PayloadTruncator.java
@@ -11,6 +11,7 @@ public class PayloadTruncator {
   private static final Charset TRANSPORT_CHARSET = Charset.forName("UTF-8");
 
   private static final TruncationStrategy[] STRATEGIES = {
+      new RollbarThreadStrategy(),
       new FramesStrategy(),
       new StringsStrategy(1024),
       new StringsStrategy(512),

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/PayloadTruncator.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/PayloadTruncator.java
@@ -13,6 +13,7 @@ public class PayloadTruncator {
   private static final TruncationStrategy[] STRATEGIES = {
       new RollbarThreadStrategy(),
       new FramesStrategy(),
+      new TelemetryEventsStrategy(),
       new StringsStrategy(1024),
       new StringsStrategy(512),
       new StringsStrategy(256),

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/RollbarThreadStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/RollbarThreadStrategy.java
@@ -1,0 +1,65 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.Data;
+import com.rollbar.api.payload.data.body.Body;
+import com.rollbar.api.payload.data.body.Group;
+import com.rollbar.api.payload.data.body.RollbarThread;
+import com.rollbar.api.payload.data.body.TraceChain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RollbarThreadStrategy implements TruncationStrategy {
+  private static final FramesStrategy FRAMES_STRATEGY = new FramesStrategy();
+
+  @Override
+  public TruncationResult<Payload> truncate(Payload payload) {
+    if (payload == null || payload.getData() == null || payload.getData().getBody() == null) {
+      return TruncationResult.none();
+    }
+
+    Body body = payload.getData().getBody();
+    List<RollbarThread> rollbarThreads = body.getRollbarThreads();
+    if (rollbarThreads == null) {
+      return TruncationResult.none();
+    }
+
+    TruncationResult<List<RollbarThread>> truncationResult = truncateRollbarThreads(rollbarThreads);
+    if (!truncationResult.wasTruncated) {
+      return TruncationResult.none();
+    }
+
+    Payload newPayload = new Payload.Builder(payload).data(
+        new Data.Builder(payload.getData()).body(
+            new Body.Builder(payload.getData().getBody())
+                .rollbarThreads(truncationResult.value).build()
+        ).build()
+    ).build();
+
+    return TruncationResult.truncated(newPayload);
+  }
+
+  private TruncationResult<List<RollbarThread>> truncateRollbarThreads(List<RollbarThread> rollbarThreads) {
+    boolean truncated = false;
+    ArrayList<RollbarThread> truncatedThreads = new ArrayList<>();
+    for(RollbarThread rollbarThread: rollbarThreads) {
+      TraceChain traceChain = rollbarThread.getGroup().getTraceChain();
+
+      TruncationResult<TraceChain> result = FRAMES_STRATEGY.truncateTraceChain(traceChain);
+      if (result.wasTruncated) {
+        truncated = true;
+        traceChain = result.value;
+      }
+
+      RollbarThread truncatedThread = new RollbarThread.Builder(rollbarThread).group(new Group(traceChain)).build();
+      truncatedThreads.add(truncatedThread);
+    }
+
+    if (truncated) {
+      return TruncationResult.truncated(truncatedThreads);
+    } else {
+      return TruncationResult.none();
+    }
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/RollbarThreadStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/RollbarThreadStrategy.java
@@ -40,10 +40,12 @@ public class RollbarThreadStrategy implements TruncationStrategy {
     return TruncationResult.truncated(newPayload);
   }
 
-  private TruncationResult<List<RollbarThread>> truncateRollbarThreads(List<RollbarThread> rollbarThreads) {
+  private TruncationResult<List<RollbarThread>> truncateRollbarThreads(
+      List<RollbarThread> rollbarThreads
+  ) {
     boolean truncated = false;
     ArrayList<RollbarThread> truncatedThreads = new ArrayList<>();
-    for(RollbarThread rollbarThread: rollbarThreads) {
+    for (RollbarThread rollbarThread: rollbarThreads) {
       TraceChain traceChain = rollbarThread.getGroup().getTraceChain();
 
       TruncationResult<TraceChain> result = FRAMES_STRATEGY.truncateTraceChain(traceChain);
@@ -52,7 +54,9 @@ public class RollbarThreadStrategy implements TruncationStrategy {
         traceChain = result.value;
       }
 
-      RollbarThread truncatedThread = new RollbarThread.Builder(rollbarThread).group(new Group(traceChain)).build();
+      RollbarThread truncatedThread = new RollbarThread
+          .Builder(rollbarThread)
+          .group(new Group(traceChain)).build();
       truncatedThreads.add(truncatedThread);
     }
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/truncation/TelemetryEventsStrategy.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/truncation/TelemetryEventsStrategy.java
@@ -1,0 +1,42 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.Data;
+import com.rollbar.api.payload.data.TelemetryEvent;
+import com.rollbar.api.payload.data.body.Body;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TelemetryEventsStrategy implements TruncationStrategy {
+  private static final int MAX_EVENTS = 10;
+
+  @Override
+  public TruncationResult<Payload> truncate(Payload payload) {
+    if (payload == null || payload.getData() == null || payload.getData().getBody() == null) {
+      return TruncationResult.none();
+    }
+
+    Body body = payload.getData().getBody();
+    List<TelemetryEvent> telemetryEvents = body.getTelemetryEvents();
+    if (telemetryEvents == null || telemetryEvents.size() <= MAX_EVENTS) {
+      return TruncationResult.none();
+    }
+
+    ArrayList<TelemetryEvent> truncatedTelemetryEvents = new ArrayList<>();
+    for (int i = 0; i < MAX_EVENTS; i++) {
+      truncatedTelemetryEvents.add(telemetryEvents.get(i));
+    }
+
+    Payload newPayload = new Payload.Builder(payload).data(
+        new Data.Builder(payload.getData()).body(
+            new Body
+                .Builder(payload.getData().getBody())
+                .telemetryEvents(truncatedTelemetryEvents)
+                .build()
+        ).build()
+    ).build();
+
+    return TruncationResult.truncated(newPayload);
+  }
+}

--- a/rollbar-java/src/main/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandler.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandler.java
@@ -26,7 +26,7 @@ public class RollbarUncaughtExceptionHandler implements Thread.UncaughtException
 
   @Override
   public void uncaughtException(Thread thread, Throwable throwable) {
-    rollbar.log(throwable, null, null, null, true);
+    rollbar.log(throwable, thread, null, null, null, true);
 
     if (delegate != null) {
       delegate.uncaughtException(thread, throwable);

--- a/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
@@ -1,14 +1,21 @@
 package com.rollbar.notifier.util;
 
 import com.rollbar.api.payload.data.TelemetryEvent;
-import com.rollbar.api.payload.data.body.*;
+import com.rollbar.api.payload.data.body.Body;
+import com.rollbar.api.payload.data.body.BodyContent;
+import com.rollbar.api.payload.data.body.ExceptionInfo;
+import com.rollbar.api.payload.data.body.Frame;
+import com.rollbar.api.payload.data.body.Group;
+import com.rollbar.api.payload.data.body.Message;
+import com.rollbar.api.payload.data.body.RollbarThread;
+import com.rollbar.api.payload.data.body.Trace;
+import com.rollbar.api.payload.data.body.TraceChain;
 import com.rollbar.jvmti.CacheFrame;
 import com.rollbar.jvmti.ThrowableCache;
 import com.rollbar.notifier.wrapper.RollbarThrowableWrapper;
 import com.rollbar.notifier.wrapper.ThrowableWrapper;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -56,18 +63,18 @@ public class BodyFactory {
    * @return the body.
    */
   public Body from(
-    ThrowableWrapper throwableWrapper,
-    String description,
-    List<TelemetryEvent> telemetryEvents
+      ThrowableWrapper throwableWrapper,
+      String description,
+      List<TelemetryEvent> telemetryEvents
   ) {
     Body.Builder builder = new Body.Builder().telemetryEvents(telemetryEvents);
     return from(throwableWrapper, description, builder);
   }
 
   private Body from(
-    ThrowableWrapper throwableWrapper,
-    String description,
-    Body.Builder builder
+      ThrowableWrapper throwableWrapper,
+      String description,
+      Body.Builder builder
   ) {
     return builder
       .bodyContent(makeBodyContent(throwableWrapper, description))
@@ -76,8 +83,8 @@ public class BodyFactory {
   }
 
   private List<RollbarThread> makeRollbarThreads(
-    ThrowableWrapper throwableWrapper,
-    String description
+      ThrowableWrapper throwableWrapper,
+      String description
   ) {
     if (throwableWrapper == null) {
       return null;
@@ -92,14 +99,17 @@ public class BodyFactory {
     return addOtherThreads(rollbarThreads, allStackTraces);
   }
 
-  private RollbarThread makeInitialRollbarThread(ThrowableWrapper throwableWrapper, String description) {
+  private RollbarThread makeInitialRollbarThread(
+      ThrowableWrapper throwableWrapper,
+      String description
+  ) {
     TraceChain traceChain = traceChain(throwableWrapper, description);
     return new RollbarThread(throwableWrapper.getThread(), new Group(traceChain));
   }
 
   private ArrayList<RollbarThread> addOtherThreads(
-    ArrayList<RollbarThread> rollbarThreads,
-    Map<Thread, StackTraceElement[]> allStackTraces
+      ArrayList<RollbarThread> rollbarThreads,
+      Map<Thread, StackTraceElement[]> allStackTraces
   ) {
     for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
       TraceChain traceChain = traceChain(entry.getValue());

--- a/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
@@ -184,7 +184,7 @@ public class BodyFactory {
 
     ArrayList<Frame> result = new ArrayList<>();
     for (int i = stackTraceElements.length - 1; i >= 0; i--) {
-      result.add(frame(stackTraceElements[i], Collections.emptyMap()));
+      result.add(frame(stackTraceElements[i], null));
     }
 
     return result;

--- a/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/util/BodyFactory.java
@@ -71,11 +71,11 @@ public class BodyFactory {
   ) {
     return builder
       .bodyContent(makeBodyContent(throwableWrapper, description))
-      .rollbarThreads(makeRollbarThreads(throwableWrapper, description))
+      .groups(makeGroups(throwableWrapper, description))
       .build();
   }
 
-  private List<RollbarThread> makeRollbarThreads(
+  private List<Group> makeGroups(
     ThrowableWrapper throwableWrapper,
     String description
   ) {
@@ -90,7 +90,9 @@ public class BodyFactory {
 
     ArrayList<RollbarThread> rollbarThreads = new ArrayList<>();
     rollbarThreads.add(makeInitialRollbarThread(throwableWrapper, description));
-    return addOtherThreads(rollbarThreads, allStackTraces);
+    ArrayList<Group> groups = new ArrayList<>();
+    groups.add(new Group(addOtherThreads(rollbarThreads, allStackTraces)));
+    return groups;
   }
 
   private RollbarThread makeInitialRollbarThread(ThrowableWrapper throwableWrapper, String description) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
@@ -1,5 +1,8 @@
 package com.rollbar.notifier.wrapper;
 
+import com.rollbar.api.payload.data.body.RollbarThread;
+import com.rollbar.notifier.util.BodyFactory;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +22,7 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
 
   private final Throwable throwable;
 
-  private final Thread thread;
+  private final RollbarThread rollbarThread;
 
   private final Map<Thread, StackTraceElement[]> allStackTraces;
 
@@ -36,7 +39,7 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       getInnerThrowableWrapper(throwable),
       throwable,
       Thread.currentThread(),
-       captureAllStackTraces(Thread.currentThread())
+      captureAllStackTraces(Thread.currentThread())
     );
   }
 
@@ -139,7 +142,7 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
     this.stackTraceElements = stackTraceElements;
     this.cause = cause;
     this.throwable = throwable;
-    this.thread = thread;
+    this.rollbarThread = new BodyFactory().from(thread);
     this.allStackTraces = allStackTraces;
   }
 
@@ -169,8 +172,8 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
   }
 
   @Override
-  public Thread getThread() {
-    return thread;
+  public RollbarThread getRollbarThread() {
+    return rollbarThread;
   }
 
   @Override
@@ -186,8 +189,7 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       + ", stackTraceElements=" + Arrays.toString(stackTraceElements)
       + ", cause=" + cause
       + ", throwable=" + throwable
-      + ", thread=" + thread
-      + ", threads=" + allStackTraces
+      + ", rollbarThread=" + rollbarThread
       + '}';
   }
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
@@ -53,11 +53,11 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
       throwable,
       thread,
-      getAllStackTraces(thread)
+      captureAllStackTraces(thread)
     );
   }
 
-  private static Map<Thread, StackTraceElement[]> getAllStackTraces(Thread thread) {
+  private static Map<Thread, StackTraceElement[]> captureAllStackTraces(Thread thread) {
     if (thread == null) {
       return null;
     }
@@ -65,7 +65,10 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
     return filter(thread, Thread.getAllStackTraces());
   }
 
-  private static Map<Thread, StackTraceElement[]> filter(Thread thread, Map<Thread, StackTraceElement[]> allStackTraces) {
+  private static Map<Thread, StackTraceElement[]> filter(
+      Thread thread, Map<Thread,
+      StackTraceElement[]> allStackTraces
+  ) {
     HashMap<Thread, StackTraceElement[]> filteredStackTraces = new HashMap<>();
 
     for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
@@ -88,22 +91,22 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
    * @param cause              the cause.
    */
   public RollbarThrowableWrapper(
-    String className,
-    String message,
-    StackTraceElement[] stackTraceElements,
-    ThrowableWrapper cause
+      String className,
+      String message,
+      StackTraceElement[] stackTraceElements,
+      ThrowableWrapper cause
   ) {
     this(className, message, stackTraceElements, cause, null, null, null);
   }
 
   private RollbarThrowableWrapper(
-    String className,
-    String message,
-    StackTraceElement[] stackTraceElements,
-    ThrowableWrapper cause,
-    Throwable throwable,
-    Thread thread,
-    Map<Thread, StackTraceElement[]> allStackTraces
+      String className,
+      String message,
+      StackTraceElement[] stackTraceElements,
+      ThrowableWrapper cause,
+      Throwable throwable,
+      Thread thread,
+      Map<Thread, StackTraceElement[]> allStackTraces
   ) {
     this.className = className;
     this.message = message;

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
@@ -33,10 +33,10 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       throwable.getClass().getName(),
       throwable.getMessage(),
       throwable.getStackTrace(),
-      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
+      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause(), false) : null,
       throwable,
-      null,
-      null
+      Thread.currentThread(),
+       captureAllStackTraces(Thread.currentThread())
     );
   }
 
@@ -50,10 +50,29 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       throwable.getClass().getName(),
       throwable.getMessage(),
       throwable.getStackTrace(),
-      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
+      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause(), false) : null,
       throwable,
       thread,
       captureAllStackTraces(thread)
+    );
+  }
+
+  /**
+   * Private constructor used to not capture all stack traces in a trace chain
+   * The unused parameter is used to have a method overload.
+   *
+   * @param throwable the throwable.
+   * @param unusedParameter used to differentiate signatures.
+   */
+  private RollbarThrowableWrapper(Throwable throwable, boolean unusedParameter) {
+    this(
+        throwable.getClass().getName(),
+        throwable.getMessage(),
+        throwable.getStackTrace(),
+        throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause(), false) : null,
+        throwable,
+        null,
+        null
     );
   }
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
@@ -33,7 +33,7 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       throwable.getClass().getName(),
       throwable.getMessage(),
       throwable.getStackTrace(),
-      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause(), false) : null,
+      getInnerThrowableWrapper(throwable),
       throwable,
       Thread.currentThread(),
        captureAllStackTraces(Thread.currentThread())
@@ -50,7 +50,7 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
       throwable.getClass().getName(),
       throwable.getMessage(),
       throwable.getStackTrace(),
-      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause(), false) : null,
+      getInnerThrowableWrapper(throwable),
       throwable,
       thread,
       captureAllStackTraces(thread)
@@ -69,11 +69,18 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
         throwable.getClass().getName(),
         throwable.getMessage(),
         throwable.getStackTrace(),
-        throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause(), false) : null,
+        getInnerThrowableWrapper(throwable),
         throwable,
         null,
         null
     );
+  }
+
+  private static ThrowableWrapper getInnerThrowableWrapper(Throwable throwable) {
+    if (throwable.getCause() == null) {
+      return null;
+    }
+    return new RollbarThrowableWrapper(throwable.getCause(), false);
   }
 
   private static Map<Thread, StackTraceElement[]> captureAllStackTraces(Thread thread) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapper.java
@@ -1,6 +1,8 @@
 package com.rollbar.notifier.wrapper;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Implementation of the {@link ThrowableWrapper throwable wrapper}.
@@ -17,38 +19,99 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
 
   private final Throwable throwable;
 
+  private final Thread thread;
+
+  private final Map<Thread, StackTraceElement[]> allStackTraces;
+
   /**
    * Constructor.
    *
    * @param throwable the throwable.
    */
   public RollbarThrowableWrapper(Throwable throwable) {
-    this(throwable.getClass().getName(), throwable.getMessage(), throwable.getStackTrace(),
-        throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
-        throwable);
+    this(
+      throwable.getClass().getName(),
+      throwable.getMessage(),
+      throwable.getStackTrace(),
+      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
+      throwable,
+      null,
+      null
+    );
   }
 
   /**
    * Constructor.
    *
-   * @param className the class name.
-   * @param message the message.
-   * @param stackTraceElements the stack trace elements.
-   * @param cause the cause.
+   * @param throwable the throwable.
    */
-  public RollbarThrowableWrapper(String className, String message,
-      StackTraceElement[] stackTraceElements,
-      ThrowableWrapper cause) {
-    this(className, message, stackTraceElements, cause, null);
+  public RollbarThrowableWrapper(Throwable throwable, Thread thread) {
+    this(
+      throwable.getClass().getName(),
+      throwable.getMessage(),
+      throwable.getStackTrace(),
+      throwable.getCause() != null ? new RollbarThrowableWrapper(throwable.getCause()) : null,
+      throwable,
+      thread,
+      getAllStackTraces(thread)
+    );
   }
 
-  private RollbarThrowableWrapper(String className, String message,
-      StackTraceElement[] stackTraceElements, ThrowableWrapper cause, Throwable throwable) {
+  private static Map<Thread, StackTraceElement[]> getAllStackTraces(Thread thread) {
+    if (thread == null) {
+      return null;
+    }
+
+    return filter(thread, Thread.getAllStackTraces());
+  }
+
+  private static Map<Thread, StackTraceElement[]> filter(Thread thread, Map<Thread, StackTraceElement[]> allStackTraces) {
+    HashMap<Thread, StackTraceElement[]> filteredStackTraces = new HashMap<>();
+
+    for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
+      Thread entryThread = entry.getKey();
+
+      if (!thread.equals(entryThread)) {
+        filteredStackTraces.put(entryThread, entry.getValue());
+      }
+    }
+
+    return filteredStackTraces;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param className          the class name.
+   * @param message            the message.
+   * @param stackTraceElements the stack trace elements.
+   * @param cause              the cause.
+   */
+  public RollbarThrowableWrapper(
+    String className,
+    String message,
+    StackTraceElement[] stackTraceElements,
+    ThrowableWrapper cause
+  ) {
+    this(className, message, stackTraceElements, cause, null, null, null);
+  }
+
+  private RollbarThrowableWrapper(
+    String className,
+    String message,
+    StackTraceElement[] stackTraceElements,
+    ThrowableWrapper cause,
+    Throwable throwable,
+    Thread thread,
+    Map<Thread, StackTraceElement[]> allStackTraces
+  ) {
     this.className = className;
     this.message = message;
     this.stackTraceElements = stackTraceElements;
     this.cause = cause;
     this.throwable = throwable;
+    this.thread = thread;
+    this.allStackTraces = allStackTraces;
   }
 
   @Override
@@ -77,14 +140,26 @@ public class RollbarThrowableWrapper implements ThrowableWrapper {
   }
 
   @Override
+  public Thread getThread() {
+    return thread;
+  }
+
+  @Override
+  public Map<Thread, StackTraceElement[]> getAllStackTraces() {
+    return allStackTraces;
+  }
+
+  @Override
   public String toString() {
     return "RollbarThrowableWrapper{"
-        + "className='" + className + '\''
-        + ", message='" + message + '\''
-        + ", stackTraceElements=" + Arrays.toString(stackTraceElements)
-        + ", cause=" + cause
-        + ", throwable=" + throwable
-        + '}';
+      + "className='" + className + '\''
+      + ", message='" + message + '\''
+      + ", stackTraceElements=" + Arrays.toString(stackTraceElements)
+      + ", cause=" + cause
+      + ", throwable=" + throwable
+      + ", thread=" + thread
+      + ", threads=" + allStackTraces
+      + '}';
   }
 
   @Override

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/ThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/ThrowableWrapper.java
@@ -1,5 +1,7 @@
 package com.rollbar.notifier.wrapper;
 
+import com.rollbar.api.payload.data.body.RollbarThread;
+
 import java.util.Map;
 
 /**
@@ -42,7 +44,17 @@ public interface ThrowableWrapper {
    */
   Throwable getThrowable();
 
-  Thread getThread();
+  /**
+   * Get the RollbarThread {@link RollbarThread rollbarThread}.
+   *
+   * @return the rollbarThread.
+   */
+  RollbarThread getRollbarThread();
 
+  /**
+   * Get a map of stack traces for all live threads in the moment of the Exception.
+   *
+   * @return the map.
+   */
   Map<Thread, StackTraceElement[]> getAllStackTraces();
 }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/ThrowableWrapper.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/wrapper/ThrowableWrapper.java
@@ -1,5 +1,7 @@
 package com.rollbar.notifier.wrapper;
 
+import java.util.Map;
+
 /**
  * Throwable wrapper to wrap a {@link Throwable thowable} or to represent a not available one.
  */
@@ -39,4 +41,8 @@ public interface ThrowableWrapper {
    * @return the throwable.
    */
   Throwable getThrowable();
+
+  Thread getThread();
+
+  Map<Thread, StackTraceElement[]> getAllStackTraces();
 }

--- a/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/RollbarTest.java
@@ -4,18 +4,13 @@ import static com.rollbar.notifier.config.ConfigBuilder.withAccessToken;
 import static com.rollbar.notifier.config.ConfigBuilder.withConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.Is.isA;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.rollbar.api.payload.Payload;
 import com.rollbar.api.payload.data.Client;
@@ -42,10 +37,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.mockito.stubbing.Answer;
 
 public class RollbarTest {
 

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/RollbarThreadStrategyTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/RollbarThreadStrategyTest.java
@@ -1,0 +1,83 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.body.Body;
+import com.rollbar.notifier.truncation.TruncationStrategy.TruncationResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RollbarThreadStrategyTest {
+
+  private TestPayloadBuilder payloadBuilder;
+  private final RollbarThreadStrategy sut = new RollbarThreadStrategy();
+  private static final int MAX_FRAMES = 20;
+
+  @Before
+  public void setUp() {
+    payloadBuilder = new TestPayloadBuilder();
+  }
+
+  @Test
+  public void ifPayloadIsNullItShouldNotTruncate() {
+    TruncationResult<Payload> result = sut.truncate(null);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifDataIsNullItShouldNotTruncate() {
+    Payload payload = new Payload.Builder(payloadBuilder.createTestPayload())
+      .data(null)
+      .build();
+
+    TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifBodyIsNullItShouldNotTruncate() {
+    Payload payload = payloadBuilder.createTestPayload((Body) null);
+
+    TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifRollbarThreadsIsNullItShouldNotTruncate() {
+    Payload payload = payloadBuilder.createTestPayload();
+
+    TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifRollbarThreadsContainsFramesEqualOrLessThanMaximumItShouldNotTruncate() {
+    Payload payload = payloadBuilder.createTestPayloadSingleTraceWithRollbarThreads(MAX_FRAMES);
+
+    TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifRollbarThreadsContainsMoreFramesThanMaximumItShouldTruncate() {
+    Payload payload = payloadBuilder.createTestPayloadSingleTraceWithRollbarThreads(MAX_FRAMES + 1);
+
+    TruncationResult<Payload> result = sut.truncate(payload);
+
+    assertTrue(result.wasTruncated);
+    assertNotNull(result.value);
+    assertNotEquals(payload, result.value);
+  }
+
+  private void verifyNoTruncation(TruncationResult<Payload> result) {
+    assertFalse(result.wasTruncated);
+    assertNull(result.value);
+  }
+
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TelemetryEventsStrategyTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TelemetryEventsStrategyTest.java
@@ -1,0 +1,106 @@
+package com.rollbar.notifier.truncation;
+
+import com.rollbar.api.payload.Payload;
+import com.rollbar.api.payload.data.Level;
+import com.rollbar.api.payload.data.Source;
+import com.rollbar.api.payload.data.TelemetryEvent;
+import com.rollbar.api.payload.data.TelemetryType;
+import com.rollbar.api.payload.data.body.Body;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TelemetryEventsStrategyTest {
+
+  private TestPayloadBuilder payloadBuilder;
+  private final TelemetryEventsStrategy sut = new TelemetryEventsStrategy();
+  private static final int MAX_EVENTS = 10;
+
+  @Before
+  public void setUp() {
+    payloadBuilder = new TestPayloadBuilder();
+  }
+
+  @Test
+  public void ifPayloadIsNullItShouldNotTruncate() {
+    TruncationStrategy.TruncationResult<Payload> result = sut.truncate(null);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifDataIsNullItShouldNotTruncate() {
+    Payload payload = new Payload.Builder(payloadBuilder.createTestPayload())
+      .data(null)
+      .build();
+
+    TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifBodyIsNullItShouldNotTruncate() {
+    Payload payload = payloadBuilder.createTestPayload((Body) null);
+
+    TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifTelemetryEventsEqualOrLessThanMaximumItShouldTruncate() {
+    List<TelemetryEvent> telemetryEvents = createTelemetryEvents(MAX_EVENTS);
+    Payload payload = payloadBuilder.createTestPayloadSingleTraceWithTelemetryEvents(
+      1,
+      telemetryEvents
+    );
+
+    TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+
+    verifyNoTruncation(result);
+  }
+
+  @Test
+  public void ifTelemetryEventsAreAboveMaximumItShouldTruncate() {
+    List<TelemetryEvent> telemetryEvents = createTelemetryEvents(MAX_EVENTS + 1);
+    Payload payload = payloadBuilder.createTestPayloadSingleTraceWithTelemetryEvents(
+        1,
+        telemetryEvents
+    );
+
+    TruncationStrategy.TruncationResult<Payload> result = sut.truncate(payload);
+
+    assertTrue(result.wasTruncated);
+    assertNotNull(result.value);
+    assertNotEquals(payload, result.value);
+  }
+
+  private void verifyNoTruncation(TruncationStrategy.TruncationResult<Payload> result) {
+    assertFalse(result.wasTruncated);
+    assertNull(result.value);
+  }
+
+  private List<TelemetryEvent> createTelemetryEvents(int quantity) {
+    ArrayList<TelemetryEvent> telemetryEvents = new ArrayList<>();
+    for (int i = 0; i < quantity; i++) {
+      telemetryEvents.add(creteTelemetryEvent());
+    }
+    return telemetryEvents;
+  }
+
+  private TelemetryEvent creteTelemetryEvent() {
+    return new TelemetryEvent(
+        TelemetryType.MANUAL,
+        Level.DEBUG,
+        1L,
+        Source.CLIENT,
+        new HashMap<>()
+    );
+  }
+}

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestPayloadBuilder.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestPayloadBuilder.java
@@ -33,7 +33,17 @@ public class TestPayloadBuilder {
   }
 
   public Payload createTestPayloadSingleTraceWithRollbarThreads(int frameCount) {
-    return createTestPayload(Collections.singletonList(createFrames(frameCount)), true);
+    return createTestPayload(Collections.singletonList(createFrames(frameCount)), true, null);
+  }
+
+  public Payload createTestPayloadSingleTraceWithTelemetryEvents(
+      int frameCount,
+      List<TelemetryEvent> telemetryEvents
+  ) {
+    return createTestPayload(
+        Collections.singletonList(createFrames(frameCount)),
+        true,
+        telemetryEvents);
   }
 
   public Payload createTestPayloadSingleTrace(Trace trace) {
@@ -45,10 +55,14 @@ public class TestPayloadBuilder {
   }
 
   public Payload createTestPayload(List<List<Frame>> frameLists) {
-    return createTestPayload(frameLists, false);
+    return createTestPayload(frameLists, false, null);
   }
 
-  public Payload createTestPayload(List<List<Frame>> frameLists, boolean addRollbarThreads) {
+  public Payload createTestPayload(
+      List<List<Frame>> frameLists,
+      boolean addRollbarThreads,
+      List<TelemetryEvent> telemetryEvents
+  ) {
     List<Trace> traces = frameLists.stream().map(frameList -> new Trace.Builder()
       .exception(
         new ExceptionInfo.Builder()
@@ -76,7 +90,14 @@ public class TestPayloadBuilder {
       rollbarThreads.add(rollbarThread);
     }
 
-    return createTestPayload(new Body.Builder().bodyContent(bodyContent).rollbarThreads(rollbarThreads).build());
+    return createTestPayload(
+        new Body
+            .Builder()
+            .bodyContent(bodyContent)
+            .rollbarThreads(rollbarThreads)
+            .telemetryEvents(telemetryEvents)
+            .build()
+    );
   }
 
   public Payload createTestPayload(Body body) {

--- a/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestPayloadBuilder.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/truncation/TestPayloadBuilder.java
@@ -32,6 +32,10 @@ public class TestPayloadBuilder {
     return createTestPayloadSingleTrace(createFrames(frameCount));
   }
 
+  public Payload createTestPayloadSingleTraceWithRollbarThreads(int frameCount) {
+    return createTestPayload(Collections.singletonList(createFrames(frameCount)), true);
+  }
+
   public Payload createTestPayloadSingleTrace(Trace trace) {
     return createTestPayload(new Body.Builder().bodyContent(trace).build());
   }
@@ -41,16 +45,20 @@ public class TestPayloadBuilder {
   }
 
   public Payload createTestPayload(List<List<Frame>> frameLists) {
+    return createTestPayload(frameLists, false);
+  }
+
+  public Payload createTestPayload(List<List<Frame>> frameLists, boolean addRollbarThreads) {
     List<Trace> traces = frameLists.stream().map(frameList -> new Trace.Builder()
-        .exception(
-            new ExceptionInfo.Builder()
-                .message(makeString("Error"))
-                .description(makeString("some error"))
-                .className(makeString("com.example.TestException"))
-                .build()
-        )
-        .frames(frameList)
-        .build()).collect(Collectors.toList());
+      .exception(
+        new ExceptionInfo.Builder()
+          .message(makeString("Error"))
+          .description(makeString("some error"))
+          .className(makeString("com.example.TestException"))
+          .build()
+      )
+      .frames(frameList)
+      .build()).collect(Collectors.toList());
 
     BodyContent bodyContent;
     if (traces.size() == 1) {
@@ -59,7 +67,16 @@ public class TestPayloadBuilder {
       bodyContent = new TraceChain.Builder().traces(traces).build();
     }
 
-    return createTestPayload(new Body.Builder().bodyContent(bodyContent).build());
+    ArrayList<RollbarThread> rollbarThreads = null;
+    if (addRollbarThreads) {
+      rollbarThreads = new ArrayList<>();
+      TraceChain traceChain = new TraceChain.Builder().traces(traces).build();
+      Group group = new Group(traceChain);
+      RollbarThread rollbarThread = new RollbarThread(Thread.currentThread(), group);
+      rollbarThreads.add(rollbarThread);
+    }
+
+    return createTestPayload(new Body.Builder().bodyContent(bodyContent).rollbarThreads(rollbarThreads).build());
   }
 
   public Payload createTestPayload(Body body) {

--- a/rollbar-java/src/test/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandlerTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/uncaughtexception/RollbarUncaughtExceptionHandlerTest.java
@@ -34,7 +34,7 @@ public class RollbarUncaughtExceptionHandlerTest {
 
     sut.uncaughtException(thread, throwable);
 
-    verify(rollbar).log(throwable, null, null, null, true);
+    verify(rollbar).log(throwable, thread, null, null, null, true);
     verify(uncaughtExceptionHandler, never()).uncaughtException(thread, throwable);
   }
 
@@ -45,7 +45,7 @@ public class RollbarUncaughtExceptionHandlerTest {
 
     sut.uncaughtException(thread, throwable);
 
-    verify(rollbar).log(throwable, null, null, null, true);
+    verify(rollbar).log(throwable, thread, null, null, null, true);
     verify(uncaughtExceptionHandler).uncaughtException(thread, throwable);
   }
 

--- a/rollbar-java/src/test/java/com/rollbar/notifier/util/BodyFactoryTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/util/BodyFactoryTest.java
@@ -57,7 +57,7 @@ public class BodyFactoryTest {
     assertThat(((Message) body.getContents()).getBody(), is(DESCRIPTION));
     HashMap<String, Object> map = (HashMap<String, Object>) body.asJson();
     assertNotNull(map.get("telemetry"));
-    assertNull(map.get("threads"));
+    assertNull(map.get("group"));
   }
 
   @Test
@@ -69,7 +69,7 @@ public class BodyFactoryTest {
     assertThat(body.getContents(), is(instanceOf(Trace.class)));
     HashMap<String, Object> map = (HashMap<String, Object>) body.asJson();
     assertNull(map.get("telemetry"));
-    assertNotNull(map.get("threads"));
+    assertNotNull(map.get("group"));
   }
 
   @Test

--- a/rollbar-java/src/test/java/com/rollbar/notifier/util/BodyFactoryTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/util/BodyFactoryTest.java
@@ -96,7 +96,7 @@ public class BodyFactoryTest {
     assertThat(body.getContents(), is(instanceOf(Trace.class)));
     HashMap<String, Object> map = (HashMap<String, Object>) body.asJson();
     assertNull(map.get("telemetry"));
-    assertNotNull(map.get("group"));
+    assertNotNull(map.get("threads"));
   }
 
   @Test
@@ -152,13 +152,13 @@ public class BodyFactoryTest {
 
   private Trace getFirstTraceFromGroup(Body body) {
     HashMap<String, Object> bodyJson = (HashMap<String, Object>) body.asJson();
-    List<Group> groups = (List<Group>) bodyJson.get("group");
+    List<RollbarThread> rollbarThreads = (List<RollbarThread>) bodyJson.get("threads");
 
-    HashMap<String, Object> groupJson = (HashMap<String, Object>) groups.get(0).asJson();
-    List<RollbarThread> rollbarThreads = (List<RollbarThread>) groupJson.get("threads");
+    HashMap<String, Object> groupJson = (HashMap<String, Object>) rollbarThreads.get(0).asJson();
+    Group group = (Group) groupJson.get("group");
 
-    HashMap<String, Object> rollbarThreadJson = (HashMap<String, Object>) rollbarThreads.get(0).asJson();
-    TraceChain traceChain = (TraceChain) rollbarThreadJson.get("trace_chain");
+    List<HashMap<String, Object>> rollbarThreadJson = (List<HashMap<String, Object>>) group.asJson();
+    TraceChain traceChain = (TraceChain) rollbarThreadJson.get(0).get("trace_chain");
     return traceChain.getTraces().get(0);
   }
 

--- a/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
@@ -29,8 +29,8 @@ public class RollbarThrowableWrapperTest {
     assertThat(sut.getStackTrace(), is(throwable.getStackTrace()));
     assertThat(sut.getCause(), is(nested));
     assertThat(sut.getThrowable(), is(throwable));
-    assertNull(sut.getAllStackTraces());
-    assertNull(sut.getThread());
+    assertNotNull(sut.getAllStackTraces());
+    assertNotNull(sut.getThread());
   }
 
   @Test

--- a/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
@@ -13,7 +13,7 @@ public class RollbarThrowableWrapperTest {
     RollbarThrowableWrapper sut = new RollbarThrowableWrapper(new Exception("Any"), Thread.currentThread());
 
     assertNotNull(sut.getAllStackTraces());
-    assertNotNull(sut.getThread());
+    assertNotNull(sut.getRollbarThread());
   }
 
   @Test
@@ -30,7 +30,7 @@ public class RollbarThrowableWrapperTest {
     assertThat(sut.getCause(), is(nested));
     assertThat(sut.getThrowable(), is(throwable));
     assertNotNull(sut.getAllStackTraces());
-    assertNotNull(sut.getThread());
+    assertNotNull(sut.getRollbarThread());
   }
 
   @Test
@@ -50,7 +50,7 @@ public class RollbarThrowableWrapperTest {
     assertThat(sut.getCause(), is(cause));
     assertThat(sut.getThrowable(), is(nullValue()));
     assertNull(sut.getAllStackTraces());
-    assertNull(sut.getThread());
+    assertNull(sut.getRollbarThread());
   }
 
   @Test

--- a/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/wrapper/RollbarThrowableWrapperTest.java
@@ -2,12 +2,19 @@ package com.rollbar.notifier.wrapper;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
 public class RollbarThrowableWrapperTest {
+
+  @Test
+  public void shouldCollectThreads() {
+    RollbarThrowableWrapper sut = new RollbarThrowableWrapper(new Exception("Any"), Thread.currentThread());
+
+    assertNotNull(sut.getAllStackTraces());
+    assertNotNull(sut.getThread());
+  }
 
   @Test
   public void shouldBeCreatedByThrowable() {
@@ -22,6 +29,8 @@ public class RollbarThrowableWrapperTest {
     assertThat(sut.getStackTrace(), is(throwable.getStackTrace()));
     assertThat(sut.getCause(), is(nested));
     assertThat(sut.getThrowable(), is(throwable));
+    assertNull(sut.getAllStackTraces());
+    assertNull(sut.getThread());
   }
 
   @Test
@@ -40,6 +49,8 @@ public class RollbarThrowableWrapperTest {
     assertThat(sut.getStackTrace(), is(elements));
     assertThat(sut.getCause(), is(cause));
     assertThat(sut.getThrowable(), is(nullValue()));
+    assertNull(sut.getAllStackTraces());
+    assertNull(sut.getThread());
   }
 
   @Test
@@ -49,6 +60,6 @@ public class RollbarThrowableWrapperTest {
     RollbarThrowableWrapper sut1 = new RollbarThrowableWrapper(throwable);
     RollbarThrowableWrapper sut2 = new RollbarThrowableWrapper(throwable);
 
-    assertTrue(sut1.equals(sut2));
+    assertEquals(sut1, sut2);
   }
 }


### PR DESCRIPTION
# Description of the change

We will send information about the status of the threads in the application when sending an exception, whether it is caught or not.

- Add "threads" object to "body" in payload
- Add truncation strategy for Rollbar threads
  - For a given RollbarThread we use the same Strategy we have in a TraceChain, cutting the extra frames leaving 10 in head and 10 in tail.
- Add truncation strategy for Telemetry events
  - By default the telemetry events have a maximum capacity of 100. But when the payload is too big, we set the maximum to 10, leaving only the latest events.
- The structure of the new payload is:

 ```json
{
    "trace": {
      "exception": {
        "description": "another thing to exist",
        "message": "this is an error",
        "class": "java.lang.Error"
      },
      "frames": [
        {
          "filename": "MainActivity.java",
          "lineno": 77,
          "method": "run",
          "class_name": "com.rollbar.example.android.MainActivity$2"
        }
      ]
    },
    "threads": [{
        "id": "2",
        "name": "main",
        "state": "RUNNABLE",
        "is_main": true
        "priority": "5",
        "group": [{
            "trace_chain": [{
                "frames": [{
                        "filename": "Thread.java",
                        "lineno": 1012,
                        "method": "run",
                        "class_name": "java.lang.Thread",
                    },
                    {
                        "filename": "Daemons.java",
                        "lineno": 145,
                        "method": "run",
                        "class_name": "java.lang.Daemons$Daemon",
                    },
                ],
                "exception": {
                    "message": "Uncaught exception",
                    "class": "java.lang.RuntimeException"
                }
            }]
        }]
    }]
}

```

### Fields in a Body object
| <div style="width:10%">Field</div>   | Type | Mandatory |  Description |
| -------- | ------- | ------- | ------- |
| trace | Trace | Yes (only 1 trace, trace_chain or message object is required) | Represent a Stack Trace |
| trace_chain | List < Trace > | Yes (only 1 trace, trace_chain or message object is required) | Represents a chain of errors (Traces) |
| message | Message | Yes (only 1 trace, trace_chain or message object is required) | Represents a message (text) sent to Rollbar, possible with additional information |
| -------- | ------- | ------- | ------- |
| telemetry | List < TelemetryEvents >  | No |
| threads | List < Thread >  | No |

⚠️ whenever we send __*trace*__ and __*trace_chain*__ we are going to send __*threads*__, since these are going to be replaced by it. __*message*__ continues to be sent as usual.

# How to test

With any of the test examples we can see this new information in the payload.

### Fields in a Thread object
| <div style="width:20%">Field</div>     | Type | Mandatory | Description |
| -------- | ------- | ------- | ------- |
| state | String | No | State of the Thread, could be: <br> NEW, RUNNABLE, BLOCKED, WAITING, TIMED_WAITING or TERMINATED |
| priority | String | No | Priority level of a Thread, values would be [1, 10] |
| id | String | Yes | Positive long number generated when the Thread was created |
| name | String | No | Name of the Thread |
| is_main | Boolean | No | Boolean representing if this is a main thread |
| group | List < TraceChain > | Yes | This represent a Group of trace chains in a Thread.<br> In Java we only send 1 TraceChain per Group,<br>  in other languages like Python (ExceptionGroup) or JS (AggregatorError),<br>  it may be more TraceChains per group. |


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- https://linear.app/rollbar-inc/issue/SDK-446/anr-implementation

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
