### PR TITLE
[Feat][SDK- 354] Bump android target sdk to 33

### DIFF
--- a/examples/rollbar-android/build.gradle
+++ b/examples/rollbar-android/build.gradle
@@ -11,14 +11,14 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.rollbar.example.android"
         minSdkVersion 21
         // FIXME: Pending further discussion
         //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/rollbar-android/build.gradle
+++ b/rollbar-android/build.gradle
@@ -38,6 +38,11 @@ android {
             testCoverageEnabled true
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/rollbar-android/build.gradle
+++ b/rollbar-android/build.gradle
@@ -18,14 +18,14 @@ apply from: "$rootDir/gradle/release.gradle"
 apply from: "$rootDir/gradle/android.quality.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion '30.0.3' // Going above here requires bumping the AGP to version 4+
 
     defaultConfig {
         minSdkVersion 21
         // FIXME: Pending further discussion
         //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 30
+        targetSdkVersion 33
         consumerProguardFiles 'proguard-rules.pro'
         manifestPlaceholders = [notifierVersion: VERSION_NAME]
     }

--- a/rollbar-java/build.gradle
+++ b/rollbar-java/build.gradle
@@ -7,6 +7,9 @@ buildscript {
     dependencies {
         classpath "com.netflix.nebula:nebula-project-plugin:3.4.0"
     }
+    configurations.classpath {
+        resolutionStrategy.force 'com.netflix.nebula:nebula-gradle-interop:2.3.0'
+    }
 }
 
 apply plugin: "nebula.integtest"

--- a/rollbar-reactive-streams/build.gradle
+++ b/rollbar-reactive-streams/build.gradle
@@ -7,6 +7,9 @@ buildscript {
     dependencies {
         classpath "com.netflix.nebula:nebula-project-plugin:3.4.0"
     }
+    configurations.classpath {
+        resolutionStrategy.force 'com.netflix.nebula:nebula-gradle-interop:2.3.0'
+    }
 }
 
 apply plugin: "nebula.integtest"

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,6 @@ rootProject.name="rollbar-java-sdk"
 
 include ":rollbar-api",
         ":rollbar-java",
-        ":rollbar-android",
         ":rollbar-web",
         ":rollbar-jakarta-web",
         ":rollbar-log4j2",
@@ -16,7 +15,6 @@ include ":rollbar-api",
         ":rollbar-reactive-streams-reactor",
         ":examples:rollbar-java",
         ":examples:rollbar-web",
-        ":examples:rollbar-android",
         ":examples:rollbar-scala",
         ":examples:rollbar-log4j2",
         ":examples:rollbar-logback",
@@ -25,3 +23,13 @@ include ":rollbar-api",
         ":examples:rollbar-struts2",
         ":examples:rollbar-struts2-spring",
         ":examples:rollbar-reactive-streams-reactor"
+
+def isJava8 = JavaVersion.current() == JavaVersion.VERSION_1_8
+
+if (isJava8) {
+    println "Java 8 detected: excluding :rollbar-android and :examples:rollbar-android"
+} else {
+    println "Java ${JavaVersion.current()} detected: including Android modules"
+    include ":rollbar-android",
+            ":examples:rollbar-android"
+}


### PR DESCRIPTION
## Description of the change

- Update compile and target SDKs to 33
- Exclude Android modules from being build with Java 8 but set target compatibility with Java 8 
- Fix compilation error from [nebula dependency](https://github.com/nebula-plugins/nebula-gradle-interop/issues/20)

#### Why omit Java 8 run in Android modules

After api 31, Android classes are compiled with Java 9+, this classes contain metadata **(that's why we get this error `java.lang.AssertionError: annotationType(): unrecognized Attribute name MODULE`)** which the Java 8 compiler doesn't recognize, so we need to use Java 11 to compile, but we keep compatibility with Java 8 setting the target and source compatibility .

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
