### PR TITLE
[Feat][SDK- 537] Init ANR detector

### DIFF
--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -271,6 +271,8 @@ public class Rollbar implements Closeable {
       Log.w(TAG, "Rollbar.init() called when it was already initialized.");
     } else {
       notifier = new Rollbar(context, null, null, true, false, provider);
+      AndroidConfiguration androidConfiguration = makeDefaultAndroidConfiguration();
+      initAnrDetector(context, androidConfiguration);
     }
     return notifier;
   }


### PR DESCRIPTION
## Description of the change

Before this changes, the method `public static Rollbar init(Context context, ConfigProvider provider)` didn't initialize the ANR detector, now it initializes always, if a user want to turn it of, should use other init method we have, setting the AndroidConfiguration as null

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
