### PR TITLE
[Fix][SDK- 537] Set AndroidConfiguration Builder visibility as public

### DIFF
--- a/rollbar-android/src/main/java/com/rollbar/android/AndroidConfiguration.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/AndroidConfiguration.java
@@ -17,7 +17,7 @@ public class AndroidConfiguration {
   public static final class Builder {
     private AnrConfiguration anrConfiguration;
 
-    Builder() {
+    public Builder() {
       anrConfiguration = new AnrConfiguration.Builder().build();
     }
 


### PR DESCRIPTION
## Description of the change

Set visibility modifier as public

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
