### PR TITLE
[Feat] [SDK-399] Okhttp interceptor

### DIFF
--- a/rollbar-okhttp/README.md
+++ b/rollbar-okhttp/README.md
@@ -1,0 +1,75 @@
+# Rollbar OkHttp Integration
+
+This module provides an [OkHttp Interceptor](https://square.github.io/okhttp/features/interceptors/) that automatically captures network telemetry for the Rollbar Java SDK.
+
+It records:
+
+- **Network telemetry events** for HTTP responses with status code `>= 400` (client and server errors).
+- **Error events** for connection failures, timeouts, and other I/O exceptions.
+
+## Installation
+
+### Gradle (Kotlin DSL)
+
+```kotlin
+dependencies {
+    implementation("com.rollbar:rollbar-okhttp:<version>")
+    implementation("com.squareup.okhttp3:okhttp:<okhttp-version>")
+}
+```
+
+### Gradle (Groovy)
+
+```groovy
+dependencies {
+    implementation 'com.rollbar:rollbar-okhttp:<version>'
+    implementation 'com.squareup.okhttp3:okhttp:<okhttp-version>'
+}
+```
+
+## Usage
+
+### 1. Implement `NetworkTelemetryRecorder`
+
+```java
+NetworkTelemetryRecorder recorder = new NetworkTelemetryRecorder() {
+    @Override
+    public void recordNetworkEvent(Level level, String method, String url, String statusCode) {
+        rollbar.recordNetworkEventFor(level, method, url, statusCode);
+    }
+
+    @Override
+    public void recordErrorEvent(Exception exception) {
+        rollbar.log(exception);
+    }
+};
+```
+
+### 2. Add the interceptor to your OkHttpClient
+
+```java
+OkHttpClient client = new OkHttpClient.Builder()
+    .addInterceptor(new RollbarOkHttpInterceptor(recorder))
+    .build();
+```
+
+### 3. Make requests as usual
+
+```java
+Request request = new Request.Builder()
+    .url("https://api.example.com/data")
+    .build();
+
+Response response = client.newCall(request).execute();
+```
+
+The interceptor will automatically record telemetry events to Rollbar without interfering with the request/response flow.
+
+## Behavior
+
+| Scenario                          | Action                                                  |
+|-----------------------------------|---------------------------------------------------------|
+| Recorder is `null`                | No telemetry or log is recorded                         |
+| Response status `< 400`           | No telemetry recorded, response returned normally       |
+| Response status `>= 400`          | Records a network telemetry event with `Level.CRITICAL` |
+| Connection failure / timeout      | Records an error event, then rethrows the `IOException` |

--- a/rollbar-okhttp/README.md
+++ b/rollbar-okhttp/README.md
@@ -13,6 +13,7 @@ It records:
 
 ```kotlin
 dependencies {
+    implementation("com.rollbar:rollbar-java:<version>")
     implementation("com.rollbar:rollbar-okhttp:<version>")
     implementation("com.squareup.okhttp3:okhttp:<okhttp-version>")
 }
@@ -22,6 +23,7 @@ dependencies {
 
 ```groovy
 dependencies {
+    implementation 'com.rollbar:rollbar-java:<version>'
     implementation 'com.rollbar:rollbar-okhttp:<version>'
     implementation 'com.squareup.okhttp3:okhttp:<okhttp-version>'
 }

--- a/rollbar-okhttp/README.md
+++ b/rollbar-okhttp/README.md
@@ -37,7 +37,8 @@ dependencies {
 NetworkTelemetryRecorder recorder = new NetworkTelemetryRecorder() {
     @Override
     public void recordNetworkEvent(Level level, String method, String url, String statusCode) {
-        // url has query parameters stripped by default (see Security section below)
+        // url has userinfo, query parameters, and fragment stripped by default
+        // (see Security section below)
         rollbar.recordNetworkEventFor(level, method, url, statusCode);
     }
 
@@ -79,9 +80,9 @@ The interceptor will automatically record telemetry events to Rollbar without in
 
 ## Security
 
-URL query parameters often carry sensitive data such as API keys (`?api_key=...`), OAuth tokens (`?access_token=...`), or PII. To prevent accidental leakage to Rollbar, the interceptor **strips query parameters by default** before passing the URL to `NetworkTelemetryRecorder`.
+URLs can carry sensitive data in several components. To prevent accidental leakage to Rollbar, the interceptor **strips userinfo (basic-auth credentials), query parameters, and the fragment by default** before passing the URL to `NetworkTelemetryRecorder`.
 
-For example, a request to `https://api.example.com/charge?token=sk_live_secret` will be recorded as `https://api.example.com/charge`.
+For example, a request to `https://user:secret@api.example.com/charge?token=sk_live_secret#section` will be recorded as `https://api.example.com/charge`.
 
 If your URLs do not contain sensitive query parameters and you need them for debugging, you can opt in to the full URL by supplying a custom sanitizer:
 

--- a/rollbar-okhttp/README.md
+++ b/rollbar-okhttp/README.md
@@ -35,6 +35,7 @@ dependencies {
 NetworkTelemetryRecorder recorder = new NetworkTelemetryRecorder() {
     @Override
     public void recordNetworkEvent(Level level, String method, String url, String statusCode) {
+        // url has query parameters stripped by default (see Security section below)
         rollbar.recordNetworkEventFor(level, method, url, statusCode);
     }
 
@@ -73,3 +74,19 @@ The interceptor will automatically record telemetry events to Rollbar without in
 | Response status `< 400`           | No telemetry recorded, response returned normally       |
 | Response status `>= 400`          | Records a network telemetry event with `Level.CRITICAL` |
 | Connection failure / timeout      | Records an error event, then rethrows the `IOException` |
+
+## Security
+
+URL query parameters often carry sensitive data such as API keys (`?api_key=...`), OAuth tokens (`?access_token=...`), or PII. To prevent accidental leakage to Rollbar, the interceptor **strips query parameters by default** before passing the URL to `NetworkTelemetryRecorder`.
+
+For example, a request to `https://api.example.com/charge?token=sk_live_secret` will be recorded as `https://api.example.com/charge`.
+
+If your URLs do not contain sensitive query parameters and you need them for debugging, you can opt in to the full URL by supplying a custom sanitizer:
+
+```java
+OkHttpClient client = new OkHttpClient.Builder()
+    .addInterceptor(new RollbarOkHttpInterceptor(recorder, HttpUrl::toString))
+    .build();
+```
+
+When using a custom sanitizer, you are responsible for ensuring that sensitive query parameters are removed before the URL reaches Rollbar.

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -10,12 +10,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation(platform("org.junit:junit-bom:5.14.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
-    implementation("com.squareup.okhttp3:okhttp:4.9.2")
+    implementation("com.squareup.okhttp3:okhttp:5.3.2")
     api(project(":rollbar-api"))
 }
 

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("java")
+}
+
+group = "com.rollbar.okhttp"
+version = "2.2.0"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.2")
+    testImplementation("org.mockito:mockito-core:5.23.0")
+    implementation("com.squareup.okhttp3:okhttp:4.9.2")
+    api(project(":rollbar-api"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 group = "com.rollbar.okhttp"
-version = "2.2.0"
 
 repositories {
     mavenCentral()

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -1,12 +1,4 @@
-plugins {
-    id("java")
-}
-
 group = "com.rollbar.okhttp"
-
-repositories {
-    mavenCentral()
-}
 
 dependencies {
     testImplementation(platform("org.junit:junit-bom:5.14.3"))

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -5,7 +5,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
-    testImplementation("org.mockito:mockito-core:5.23.0")
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     api(project(":rollbar-api"))
     api("org.slf4j:slf4j-api:1.7.25")

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.23.0")
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     api(project(":rollbar-api"))
+    api("org.slf4j:slf4j-api:1.7.25")
 }
 
 tasks.test {

--- a/rollbar-okhttp/build.gradle.kts
+++ b/rollbar-okhttp/build.gradle.kts
@@ -1,5 +1,3 @@
-group = "com.rollbar.okhttp"
-
 dependencies {
     testImplementation(platform("org.junit:junit-bom:5.14.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
@@ -3,6 +3,7 @@ package com.rollbar.okhttp;
 import com.rollbar.api.payload.data.Level;
 
 public interface NetworkTelemetryRecorder {
-    void recordNetworkEvent(Level level, String method, String url, String statusCode);
-    void recordErrorEvent(Exception exception);
+  void recordNetworkEvent(Level level, String method, String url, String statusCode);
+
+  void recordErrorEvent(Exception exception);
 }

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
@@ -1,0 +1,8 @@
+package com.rollbar.okhttp;
+
+import com.rollbar.api.payload.data.Level;
+
+public interface NetworkTelemetryRecorder {
+    void recordNetworkEvent(Level level, String method, String url, String statusCode);
+    void recordErrorEvent(Exception exception);
+}

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
@@ -11,8 +11,9 @@ public interface NetworkTelemetryRecorder {
    *
    * @param level      the severity level to attach to the telemetry event
    * @param method     the HTTP method (e.g. GET, POST)
-   * @param url        the request URL with query parameters stripped by default; supply a custom
-   *                   sanitizer to {@link RollbarOkHttpInterceptor} to change this behavior
+   * @param url        the request URL with userinfo (basic-auth credentials), query parameters,
+   *                   and fragment stripped by default; supply a custom sanitizer to
+   *                   {@link RollbarOkHttpInterceptor} to change this behavior
    * @param statusCode the HTTP response status code as a string (e.g. "200", "404")
    */
   void recordNetworkEvent(Level level, String method, String url, String statusCode);

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
@@ -3,6 +3,10 @@ package com.rollbar.okhttp;
 import com.rollbar.api.payload.data.Level;
 
 public interface NetworkTelemetryRecorder {
+  /**
+   * @param url the request URL with query parameters stripped by default; supply a custom
+   *            sanitizer to {@link RollbarOkHttpInterceptor} to change this behavior.
+   */
   void recordNetworkEvent(Level level, String method, String url, String statusCode);
 
   void recordErrorEvent(Exception exception);

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/NetworkTelemetryRecorder.java
@@ -2,12 +2,25 @@ package com.rollbar.okhttp;
 
 import com.rollbar.api.payload.data.Level;
 
+/**
+ * Records network telemetry events and errors for HTTP requests.
+ */
 public interface NetworkTelemetryRecorder {
   /**
-   * @param url the request URL with query parameters stripped by default; supply a custom
-   *            sanitizer to {@link RollbarOkHttpInterceptor} to change this behavior.
+   * Records a completed network request as a telemetry event.
+   *
+   * @param level      the severity level to attach to the telemetry event
+   * @param method     the HTTP method (e.g. GET, POST)
+   * @param url        the request URL with query parameters stripped by default; supply a custom
+   *                   sanitizer to {@link RollbarOkHttpInterceptor} to change this behavior
+   * @param statusCode the HTTP response status code as a string (e.g. "200", "404")
    */
   void recordNetworkEvent(Level level, String method, String url, String statusCode);
 
+  /**
+   * Records a network error event when an HTTP request fails with an exception.
+   *
+   * @param exception the exception thrown during the request
+   */
   void recordErrorEvent(Exception exception);
 }

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -1,39 +1,44 @@
 package com.rollbar.okhttp;
 
 import com.rollbar.api.payload.data.Level;
+
+import java.io.IOException;
+
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import java.io.IOException;
-
 public class RollbarOkHttpInterceptor implements Interceptor {
 
-    private final NetworkTelemetryRecorder recorder;
+  private final NetworkTelemetryRecorder recorder;
 
-    public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder) {
-        this.recorder = recorder;
+  public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder) {
+    this.recorder = recorder;
+  }
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Request request = chain.request();
+
+    try {
+      Response response = chain.proceed(request);
+
+      if (response.code() >= 400 && recorder != null) {
+        recorder.recordNetworkEvent(
+            Level.CRITICAL,
+            request.method(),
+            request.url().toString(),
+            String.valueOf(response.code()));
+      }
+
+      return response;
+
+    } catch (IOException e) {
+      if (recorder != null) {
+        recorder.recordErrorEvent(e);
+      }
+
+      throw e;
     }
-
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-        Request request = chain.request();
-
-        try {
-            Response response = chain.proceed(request);
-
-            if (response.code() >= 400 && recorder != null) {
-                recorder.recordNetworkEvent(Level.CRITICAL, request.method(), request.url().toString(), String.valueOf(response.code()));
-            }
-
-            return response;
-
-        } catch (IOException e) {
-            if (recorder != null) {
-                recorder.recordErrorEvent(e);
-            }
-
-            throw e;
-        }
-    }
+  }
 }

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -1,0 +1,39 @@
+package com.rollbar.okhttp;
+
+import com.rollbar.api.payload.data.Level;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+public class RollbarOkHttpInterceptor implements Interceptor {
+
+    private final NetworkTelemetryRecorder recorder;
+
+    public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder) {
+        this.recorder = recorder;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+
+        try {
+            Response response = chain.proceed(request);
+
+            if (response.code() >= 400 && recorder != null) {
+                recorder.recordNetworkEvent(Level.CRITICAL, request.method(), request.url().toString(), String.valueOf(response.code()));
+            }
+
+            return response;
+
+        } catch (IOException e) {
+            if (recorder != null) {
+                recorder.recordErrorEvent(e);
+            }
+
+            throw e;
+        }
+    }
+}

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -41,11 +41,21 @@ public class RollbarOkHttpInterceptor implements Interceptor {
       Response response = chain.proceed(request);
 
       if (response.code() >= 400 && recorder != null) {
+        String sanitizedUrl;
+        try {
+          sanitizedUrl = urlSanitizer.apply(request.url());
+        } catch (Exception sanitizerException) {
+          LOGGER.log(java.util.logging.Level.WARNING,
+              "urlSanitizer threw an exception; "
+                  + "suppressing to preserve the interceptor contract.",
+              sanitizerException);
+          return response;
+        }
         try {
           recorder.recordNetworkEvent(
               Level.CRITICAL,
               request.method(),
-              urlSanitizer.apply(request.url()),
+              sanitizedUrl,
               String.valueOf(response.code()));
         } catch (Exception recorderException) {
           LOGGER.log(java.util.logging.Level.WARNING,

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -3,12 +3,15 @@ package com.rollbar.okhttp;
 import com.rollbar.api.payload.data.Level;
 
 import java.io.IOException;
+import java.util.logging.Logger;
 
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
 public class RollbarOkHttpInterceptor implements Interceptor {
+
+  private static final Logger LOGGER = Logger.getLogger(RollbarOkHttpInterceptor.class.getName());
 
   private final NetworkTelemetryRecorder recorder;
 
@@ -24,18 +27,32 @@ public class RollbarOkHttpInterceptor implements Interceptor {
       Response response = chain.proceed(request);
 
       if (response.code() >= 400 && recorder != null) {
-        recorder.recordNetworkEvent(
-            Level.CRITICAL,
-            request.method(),
-            request.url().toString(),
-            String.valueOf(response.code()));
+        try {
+          recorder.recordNetworkEvent(
+              Level.CRITICAL,
+              request.method(),
+              request.url().toString(),
+              String.valueOf(response.code()));
+        } catch (Exception recorderException) {
+          LOGGER.log(java.util.logging.Level.WARNING,
+              "NetworkTelemetryRecorder.recordNetworkEvent threw an exception; "
+                  + "suppressing to preserve the interceptor contract.",
+              recorderException);
+        }
       }
 
       return response;
 
     } catch (IOException e) {
       if (recorder != null) {
-        recorder.recordErrorEvent(e);
+        try {
+          recorder.recordErrorEvent(e);
+        } catch (Exception recorderException) {
+          LOGGER.log(java.util.logging.Level.WARNING,
+              "NetworkTelemetryRecorder.recordErrorEvent threw an exception; "
+                  + "suppressing to preserve the original IOException.",
+              recorderException);
+        }
       }
 
       throw e;

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -18,7 +18,14 @@ public class RollbarOkHttpInterceptor implements Interceptor {
   private static final Logger LOGGER = LoggerFactory.getLogger(RollbarOkHttpInterceptor.class);
 
   private static final Function<HttpUrl, String> DEFAULT_URL_SANITIZER =
-      url -> url.newBuilder().username("").password("").query(null).fragment(null).build().toString();
+      url -> url
+              .newBuilder()
+              .username("")
+              .password("")
+              .query(null)
+              .fragment(null)
+              .build()
+              .toString();
 
   private final NetworkTelemetryRecorder recorder;
   private final Function<HttpUrl, String> urlSanitizer;

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -17,7 +17,7 @@ public class RollbarOkHttpInterceptor implements Interceptor {
   private static final Logger LOGGER = Logger.getLogger(RollbarOkHttpInterceptor.class.getName());
 
   private static final Function<HttpUrl, String> DEFAULT_URL_SANITIZER =
-      url -> url.newBuilder().query(null).build().toString();
+      url -> url.newBuilder().username("").password("").query(null).fragment(null).build().toString();
 
   private final NetworkTelemetryRecorder recorder;
   private final Function<HttpUrl, String> urlSanitizer;

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -5,16 +5,17 @@ import com.rollbar.api.payload.data.Level;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RollbarOkHttpInterceptor implements Interceptor {
 
-  private static final Logger LOGGER = Logger.getLogger(RollbarOkHttpInterceptor.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(RollbarOkHttpInterceptor.class);
 
   private static final Function<HttpUrl, String> DEFAULT_URL_SANITIZER =
       url -> url.newBuilder().username("").password("").query(null).fragment(null).build().toString();
@@ -45,10 +46,8 @@ public class RollbarOkHttpInterceptor implements Interceptor {
         try {
           sanitizedUrl = urlSanitizer.apply(request.url());
         } catch (Exception sanitizerException) {
-          LOGGER.log(java.util.logging.Level.WARNING,
-              "urlSanitizer threw an exception; "
-                  + "suppressing to preserve the interceptor contract.",
-              sanitizerException);
+          LOGGER.warn("urlSanitizer threw an exception; "
+              + "suppressing to preserve the interceptor contract.", sanitizerException);
           return response;
         }
         try {
@@ -58,10 +57,8 @@ public class RollbarOkHttpInterceptor implements Interceptor {
               sanitizedUrl,
               String.valueOf(response.code()));
         } catch (Exception recorderException) {
-          LOGGER.log(java.util.logging.Level.WARNING,
-              "NetworkTelemetryRecorder.recordNetworkEvent threw an exception; "
-                  + "suppressing to preserve the interceptor contract.",
-              recorderException);
+          LOGGER.warn("NetworkTelemetryRecorder.recordNetworkEvent threw an exception; "
+              + "suppressing to preserve the interceptor contract.", recorderException);
         }
       }
 
@@ -72,10 +69,8 @@ public class RollbarOkHttpInterceptor implements Interceptor {
         try {
           recorder.recordErrorEvent(e);
         } catch (Exception recorderException) {
-          LOGGER.log(java.util.logging.Level.WARNING,
-              "NetworkTelemetryRecorder.recordErrorEvent threw an exception; "
-                  + "suppressing to preserve the original IOException.",
-              recorderException);
+          LOGGER.warn("NetworkTelemetryRecorder.recordErrorEvent threw an exception; "
+              + "suppressing to preserve the original IOException.", recorderException);
         }
       }
 

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -3,8 +3,11 @@ package com.rollbar.okhttp;
 import com.rollbar.api.payload.data.Level;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.logging.Logger;
 
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -13,10 +16,19 @@ public class RollbarOkHttpInterceptor implements Interceptor {
 
   private static final Logger LOGGER = Logger.getLogger(RollbarOkHttpInterceptor.class.getName());
 
+  private static final Function<HttpUrl, String> DEFAULT_URL_SANITIZER =
+      url -> url.newBuilder().query(null).build().toString();
+
   private final NetworkTelemetryRecorder recorder;
+  private final Function<HttpUrl, String> urlSanitizer;
 
   public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder) {
+    this(recorder, DEFAULT_URL_SANITIZER);
+  }
+
+  public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder, Function<HttpUrl, String> urlSanitizer) {
     this.recorder = recorder;
+    this.urlSanitizer = Objects.requireNonNull(urlSanitizer, "urlSanitizer must not be null");
   }
 
   @Override
@@ -31,7 +43,7 @@ public class RollbarOkHttpInterceptor implements Interceptor {
           recorder.recordNetworkEvent(
               Level.CRITICAL,
               request.method(),
-              request.url().toString(),
+              urlSanitizer.apply(request.url()),
               String.valueOf(response.code()));
         } catch (Exception recorderException) {
           LOGGER.log(java.util.logging.Level.WARNING,

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -4,12 +4,12 @@ import com.rollbar.api.payload.data.Level;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.function.Function;
 
-import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +17,7 @@ public class RollbarOkHttpInterceptor implements Interceptor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RollbarOkHttpInterceptor.class);
 
-  private static final Function<HttpUrl, String> DEFAULT_URL_SANITIZER =
+  private static final UrlSanitizer DEFAULT_URL_SANITIZER =
       url -> url
               .newBuilder()
               .username("")
@@ -28,7 +28,7 @@ public class RollbarOkHttpInterceptor implements Interceptor {
               .toString();
 
   private final NetworkTelemetryRecorder recorder;
-  private final Function<HttpUrl, String> urlSanitizer;
+  private final UrlSanitizer urlSanitizer;
 
   public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder) {
     this(recorder, DEFAULT_URL_SANITIZER);
@@ -36,11 +36,12 @@ public class RollbarOkHttpInterceptor implements Interceptor {
 
   public RollbarOkHttpInterceptor(
           NetworkTelemetryRecorder recorder,
-          Function<HttpUrl, String> urlSanitizer) {
+          UrlSanitizer urlSanitizer) {
     this.recorder = recorder;
     this.urlSanitizer = Objects.requireNonNull(urlSanitizer, "urlSanitizer must not be null");
   }
 
+  @NotNull
   @Override
   public Response intercept(Chain chain) throws IOException {
     Request request = chain.request();
@@ -51,7 +52,7 @@ public class RollbarOkHttpInterceptor implements Interceptor {
       if (response.code() >= 400 && recorder != null) {
         String sanitizedUrl;
         try {
-          sanitizedUrl = urlSanitizer.apply(request.url());
+          sanitizedUrl = urlSanitizer.sanitize(request.url());
         } catch (Exception sanitizerException) {
           LOGGER.warn("urlSanitizer threw an exception; "
               + "suppressing to preserve the interceptor contract.", sanitizerException);

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/RollbarOkHttpInterceptor.java
@@ -26,7 +26,9 @@ public class RollbarOkHttpInterceptor implements Interceptor {
     this(recorder, DEFAULT_URL_SANITIZER);
   }
 
-  public RollbarOkHttpInterceptor(NetworkTelemetryRecorder recorder, Function<HttpUrl, String> urlSanitizer) {
+  public RollbarOkHttpInterceptor(
+          NetworkTelemetryRecorder recorder,
+          Function<HttpUrl, String> urlSanitizer) {
     this.recorder = recorder;
     this.urlSanitizer = Objects.requireNonNull(urlSanitizer, "urlSanitizer must not be null");
   }

--- a/rollbar-okhttp/src/main/java/com/rollbar/okhttp/UrlSanitizer.java
+++ b/rollbar-okhttp/src/main/java/com/rollbar/okhttp/UrlSanitizer.java
@@ -1,0 +1,8 @@
+package com.rollbar.okhttp;
+
+import okhttp3.HttpUrl;
+
+@FunctionalInterface
+public interface UrlSanitizer {
+  String sanitize(HttpUrl url);
+}

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -1,0 +1,148 @@
+package com.rollbar.okhttp;
+
+import com.rollbar.api.payload.data.Level;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RollbarOkHttpInterceptorTest {
+
+    private MockWebServer server;
+    private NetworkTelemetryRecorder recorder;
+    private OkHttpClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        recorder = mock(NetworkTelemetryRecorder.class);
+
+        client = new OkHttpClient.Builder()
+                .addInterceptor(new RollbarOkHttpInterceptor(recorder))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    void successfulResponse_doesNotRecordEvent() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        Request request = new Request.Builder().url(server.url("/ok")).build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        assertEquals(200, response.code());
+        verifyNoInteractions(recorder);
+    }
+
+    @Test
+    void redirectResponse_doesNotRecordEvent() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(301).addHeader("Location", "/other"));
+
+        OkHttpClient noFollowClient = client.newBuilder().followRedirects(false).build();
+        Request request = new Request.Builder().url(server.url("/redirect")).build();
+        Response response = noFollowClient.newCall(request).execute();
+        response.close();
+
+        assertEquals(301, response.code());
+        verifyNoInteractions(recorder);
+    }
+
+    @Test
+    void clientErrorResponse_recordsNetworkEvent() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(404));
+
+        Request request = new Request.Builder().url(server.url("/not-found")).build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        assertEquals(404, response.code());
+        verify(recorder).recordNetworkEvent(
+                eq(Level.CRITICAL), eq("GET"), contains("/not-found"), eq("404"));
+        verify(recorder, never()).recordErrorEvent(any());
+    }
+
+    @Test
+    void serverErrorResponse_recordsNetworkEvent() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        Request request = new Request.Builder().url(server.url("/error")).build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        assertEquals(500, response.code());
+        verify(recorder).recordNetworkEvent(
+                eq(Level.CRITICAL), eq("GET"), contains("/error"), eq("500"));
+        verify(recorder, never()).recordErrorEvent(any());
+    }
+
+    @Test
+    void connectionFailure_recordsErrorEvent() {
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+        Request request = new Request.Builder().url(server.url("/fail")).build();
+
+        assertThrows(IOException.class, () -> client.newCall(request).execute());
+
+        verify(recorder).recordErrorEvent(any(IOException.class));
+        verify(recorder, never()).recordNetworkEvent(any(), any(), any(), any());
+    }
+
+    @Test
+    void postRequest_recordsCorrectMethod() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        Request request = new Request.Builder()
+                .url(server.url("/post"))
+                .post(okhttp3.RequestBody.create("body", okhttp3.MediaType.parse("text/plain")))
+                .build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        verify(recorder).recordNetworkEvent(eq(Level.CRITICAL), eq("POST"), any(), eq("500"));
+    }
+
+    @Test
+    void nullRecorder_errorResponse_doesNotThrowNPE() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        OkHttpClient nullRecorderClient = new OkHttpClient.Builder()
+                .addInterceptor(new RollbarOkHttpInterceptor(null))
+                .build();
+
+        Request request = new Request.Builder().url(server.url("/error")).build();
+        Response response = nullRecorderClient.newCall(request).execute();
+        response.close();
+
+        assertEquals(500, response.code());
+    }
+
+    @Test
+    void nullRecorder_connectionFailure_doesNotThrow() {
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+        OkHttpClient nullRecorderClient = new OkHttpClient.Builder()
+                .addInterceptor(new RollbarOkHttpInterceptor(null))
+                .build();
+
+        Request request = new Request.Builder().url(server.url("/fail")).build();
+
+        assertThrows(IOException.class, () -> nullRecorderClient.newCall(request).execute());
+    }
+}

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -206,6 +206,7 @@ class RollbarOkHttpInterceptorTest {
         Response response = customClient.newCall(request).execute();
         response.close();
 
-        verify(recorder).recordNetworkEvent(eq(Level.CRITICAL), eq("GET"), eq("Updated String"), eq("500"));
+        verify(recorder).recordNetworkEvent(
+                eq(Level.CRITICAL), eq("GET"), eq("Updated String"), eq("500"));
     }
 }

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -18,239 +18,239 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
-class RollbarOkHttpInterceptorTest {
+public class RollbarOkHttpInterceptorTest {
 
-    private MockWebServer server;
-    private NetworkTelemetryRecorder recorder;
-    private OkHttpClient client;
+  private MockWebServer server;
+  private NetworkTelemetryRecorder recorder;
+  private OkHttpClient client;
 
-    @BeforeEach
-    void setUp() throws IOException {
-        server = new MockWebServer();
-        server.start();
+  @BeforeEach
+  public void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
 
-        recorder = mock(NetworkTelemetryRecorder.class);
+    recorder = mock(NetworkTelemetryRecorder.class);
 
-        client = new OkHttpClient.Builder()
-                .addInterceptor(new RollbarOkHttpInterceptor(recorder))
-                .build();
-    }
+    client = new OkHttpClient.Builder()
+        .addInterceptor(new RollbarOkHttpInterceptor(recorder))
+        .build();
+  }
 
-    @AfterEach
-    void tearDown() throws IOException {
-        server.shutdown();
-    }
+  @AfterEach
+  public void tearDown() throws IOException {
+    server.shutdown();
+  }
 
-    @Test
-    void successfulResponse_doesNotRecordEvent() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(200));
+  @Test
+  public void successfulResponse_doesNotRecordEvent() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(200));
 
-        Request request = new Request.Builder().url(server.url("/ok")).build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(server.url("/ok")).build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        assertEquals(200, response.code());
-        verifyNoInteractions(recorder);
-    }
+    assertEquals(200, response.code());
+    verifyNoInteractions(recorder);
+  }
 
-    @Test
-    void redirectResponse_doesNotRecordEvent() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(301).addHeader("Location", "/other"));
+  @Test
+  public void redirectResponse_doesNotRecordEvent() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(301).addHeader("Location", "/other"));
 
-        OkHttpClient noFollowClient = client.newBuilder().followRedirects(false).build();
-        Request request = new Request.Builder().url(server.url("/redirect")).build();
-        Response response = noFollowClient.newCall(request).execute();
-        response.close();
+    OkHttpClient noFollowClient = client.newBuilder().followRedirects(false).build();
+    Request request = new Request.Builder().url(server.url("/redirect")).build();
+    Response response = noFollowClient.newCall(request).execute();
+    response.close();
 
-        assertEquals(301, response.code());
-        verifyNoInteractions(recorder);
-    }
+    assertEquals(301, response.code());
+    verifyNoInteractions(recorder);
+  }
 
-    @Test
-    void clientErrorResponse_recordsNetworkEvent() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(404));
+  @Test
+  public void clientErrorResponse_recordsNetworkEvent() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(404));
 
-        Request request = new Request.Builder().url(server.url("/not-found")).build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(server.url("/not-found")).build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        assertEquals(404, response.code());
-        verify(recorder).recordNetworkEvent(
-                eq(Level.CRITICAL), eq("GET"), contains("/not-found"), eq("404"));
-        verify(recorder, never()).recordErrorEvent(any());
-    }
+    assertEquals(404, response.code());
+    verify(recorder).recordNetworkEvent(
+        eq(Level.CRITICAL), eq("GET"), contains("/not-found"), eq("404"));
+    verify(recorder, never()).recordErrorEvent(any());
+  }
 
-    @Test
-    void serverErrorResponse_recordsNetworkEvent() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void serverErrorResponse_recordsNetworkEvent() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        Request request = new Request.Builder().url(server.url("/error")).build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(server.url("/error")).build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        assertEquals(500, response.code());
-        verify(recorder).recordNetworkEvent(
-                eq(Level.CRITICAL), eq("GET"), contains("/error"), eq("500"));
-        verify(recorder, never()).recordErrorEvent(any());
-    }
+    assertEquals(500, response.code());
+    verify(recorder).recordNetworkEvent(
+        eq(Level.CRITICAL), eq("GET"), contains("/error"), eq("500"));
+    verify(recorder, never()).recordErrorEvent(any());
+  }
 
-    @Test
-    void connectionFailure_recordsErrorEvent() {
-        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+  @Test
+  public void connectionFailure_recordsErrorEvent() {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
-        Request request = new Request.Builder().url(server.url("/fail")).build();
+    Request request = new Request.Builder().url(server.url("/fail")).build();
 
-        assertThrows(IOException.class, () -> client.newCall(request).execute());
+    assertThrows(IOException.class, () -> client.newCall(request).execute());
 
-        verify(recorder).recordErrorEvent(any(IOException.class));
-        verify(recorder, never()).recordNetworkEvent(any(), any(), any(), any());
-    }
+    verify(recorder).recordErrorEvent(any(IOException.class));
+    verify(recorder, never()).recordNetworkEvent(any(), any(), any(), any());
+  }
 
-    @Test
-    void postRequest_recordsCorrectMethod() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void postRequest_recordsCorrectMethod() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        Request request = new Request.Builder()
-                .url(server.url("/post"))
-                .post(okhttp3.RequestBody.create("body", okhttp3.MediaType.parse("text/plain")))
-                .build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder()
+        .url(server.url("/post"))
+        .post(okhttp3.RequestBody.create("body", okhttp3.MediaType.parse("text/plain")))
+        .build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        verify(recorder).recordNetworkEvent(eq(Level.CRITICAL), eq("POST"), any(), eq("500"));
-    }
+    verify(recorder).recordNetworkEvent(eq(Level.CRITICAL), eq("POST"), any(), eq("500"));
+  }
 
-    @Test
-    void nullRecorder_errorResponse_doesNotThrowNPE() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void nullRecorder_errorResponse_doesNotThrowNPE() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        OkHttpClient nullRecorderClient = new OkHttpClient.Builder()
-                .addInterceptor(new RollbarOkHttpInterceptor(null))
-                .build();
+    OkHttpClient nullRecorderClient = new OkHttpClient.Builder()
+        .addInterceptor(new RollbarOkHttpInterceptor(null))
+        .build();
 
-        Request request = new Request.Builder().url(server.url("/error")).build();
-        Response response = nullRecorderClient.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(server.url("/error")).build();
+    Response response = nullRecorderClient.newCall(request).execute();
+    response.close();
 
-        assertEquals(500, response.code());
-    }
+    assertEquals(500, response.code());
+  }
 
-    @Test
-    void nullRecorder_connectionFailure_doesNotThrow() {
-        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+  @Test
+  public void nullRecorder_connectionFailure_doesNotThrow() {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
-        OkHttpClient nullRecorderClient = new OkHttpClient.Builder()
-                .addInterceptor(new RollbarOkHttpInterceptor(null))
-                .build();
+    OkHttpClient nullRecorderClient = new OkHttpClient.Builder()
+        .addInterceptor(new RollbarOkHttpInterceptor(null))
+        .build();
 
-        Request request = new Request.Builder().url(server.url("/fail")).build();
+    Request request = new Request.Builder().url(server.url("/fail")).build();
 
-        assertThrows(IOException.class, () -> nullRecorderClient.newCall(request).execute());
-    }
+    assertThrows(IOException.class, () -> nullRecorderClient.newCall(request).execute());
+  }
 
-    @Test
-    void recorderThrowsOnErrorResponse_responseStillReturned() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void recorderThrowsOnErrorResponse_responseStillReturned() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        doThrow(new RuntimeException("recorder boom"))
-                .when(recorder)
-                .recordNetworkEvent(any(), any(), any(), any());
+    doThrow(new RuntimeException("recorder boom"))
+        .when(recorder)
+        .recordNetworkEvent(any(), any(), any(), any());
 
-        Request request = new Request.Builder().url(server.url("/error")).build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(server.url("/error")).build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        assertEquals(500, response.code());
-    }
+    assertEquals(500, response.code());
+  }
 
-    @Test
-    void recorderThrowsOnConnectionFailure_originalIOExceptionPropagates() {
-        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+  @Test
+  public void recorderThrowsOnConnectionFailure_originalIOExceptionPropagates() {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
-        doThrow(new RuntimeException("recorder boom"))
-                .when(recorder)
-                .recordErrorEvent(any());
+    doThrow(new RuntimeException("recorder boom"))
+        .when(recorder)
+        .recordErrorEvent(any());
 
-        Request request = new Request.Builder().url(server.url("/fail")).build();
+    Request request = new Request.Builder().url(server.url("/fail")).build();
 
-        assertThrows(IOException.class, () -> client.newCall(request).execute());
-        verify(recorder).recordErrorEvent(any(IOException.class));
-    }
+    assertThrows(IOException.class, () -> client.newCall(request).execute());
+    verify(recorder).recordErrorEvent(any(IOException.class));
+  }
 
-    @Test
-    void defaultSanitizer_stripsQueryParamsFromUrl() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void defaultSanitizer_stripsQueryParamsFromUrl() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        Request request = new Request.Builder()
-                .url(server.url("/sensitive?token=sk_live_secret&email=user@example.com"))
-                .build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder()
+        .url(server.url("/sensitive?token=sk_live_secret&email=user@example.com"))
+        .build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        verify(recorder).recordNetworkEvent(
-                eq(Level.CRITICAL), eq("GET"),
-                argThat(url -> url.contains("/sensitive") && !url.contains("secret") && !url.contains("email")),
-                eq("500"));
-    }
+    verify(recorder).recordNetworkEvent(
+        eq(Level.CRITICAL), eq("GET"),
+        argThat(url -> url.contains("/sensitive") && !url.contains("secret") && !url.contains("email")),
+        eq("500"));
+  }
 
-    @Test
-    void defaultSanitizer_stripsCredentialsAndFragment() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void defaultSanitizer_stripsCredentialsAndFragment() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        HttpUrl urlWithCredentials = server.url("/charge")
-                .newBuilder()
-                .username("anyUser")
-                .password("anyPassword")
-                .addQueryParameter("token", "abc")
-                .fragment("section")
-                .build();
+    HttpUrl urlWithCredentials = server.url("/charge")
+        .newBuilder()
+        .username("anyUser")
+        .password("anyPassword")
+        .addQueryParameter("token", "abc")
+        .fragment("section")
+        .build();
 
-        Request request = new Request.Builder().url(urlWithCredentials).build();
-        Response response = client.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(urlWithCredentials).build();
+    Response response = client.newCall(request).execute();
+    response.close();
 
-        verify(recorder).recordNetworkEvent(
-                eq(Level.CRITICAL), eq("GET"),
-                argThat(url -> url.contains("/charge")
-                        && !url.contains("anyUser")
-                        && !url.contains("anyPassword")
-                        && !url.contains("token")
-                        && !url.contains("section")),
-                eq("500"));
-    }
+    verify(recorder).recordNetworkEvent(
+        eq(Level.CRITICAL), eq("GET"),
+        argThat(url -> url.contains("/charge")
+            && !url.contains("anyUser")
+            && !url.contains("anyPassword")
+            && !url.contains("token")
+            && !url.contains("section")),
+        eq("500"));
+  }
 
-    @Test
-    void customSanitizerThrows_responseStillReturnedAndRecorderNotCalled() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void customSanitizerThrows_responseStillReturnedAndRecorderNotCalled() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        OkHttpClient throwingClient = new OkHttpClient.Builder()
-                .addInterceptor(new RollbarOkHttpInterceptor(recorder,
-                        url -> { throw new IllegalStateException("bad url"); }))
-                .build();
+    OkHttpClient throwingClient = new OkHttpClient.Builder()
+        .addInterceptor(new RollbarOkHttpInterceptor(recorder,
+            url -> { throw new IllegalStateException("bad url"); }))
+        .build();
 
-        Request request = new Request.Builder().url(server.url("/error")).build();
-        Response response = throwingClient.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder().url(server.url("/error")).build();
+    Response response = throwingClient.newCall(request).execute();
+    response.close();
 
-        assertEquals(500, response.code());
-        verify(recorder, never()).recordNetworkEvent(any(), any(), any(), any());
-    }
+    assertEquals(500, response.code());
+    verify(recorder, never()).recordNetworkEvent(any(), any(), any(), any());
+  }
 
-    @Test
-    void customSanitizer_isAppliedToUrl() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(500));
+  @Test
+  public void customSanitizer_isAppliedToUrl() throws IOException {
+    server.enqueue(new MockResponse().setResponseCode(500));
 
-        OkHttpClient customClient = new OkHttpClient.Builder()
-                .addInterceptor(new RollbarOkHttpInterceptor(recorder, url -> "Updated String"))
-                .build();
+    OkHttpClient customClient = new OkHttpClient.Builder()
+        .addInterceptor(new RollbarOkHttpInterceptor(recorder, url -> "Updated String"))
+        .build();
 
-        Request request = new Request.Builder()
-                .url(server.url("/path?secret=abc"))
-                .build();
-        Response response = customClient.newCall(request).execute();
-        response.close();
+    Request request = new Request.Builder()
+        .url(server.url("/path?secret=abc"))
+        .build();
+    Response response = customClient.newCall(request).execute();
+    response.close();
 
-        verify(recorder).recordNetworkEvent(
-                eq(Level.CRITICAL), eq("GET"), eq("Updated String"), eq("500"));
-    }
+    verify(recorder).recordNetworkEvent(
+        eq(Level.CRITICAL), eq("GET"), eq("Updated String"), eq("500"));
+  }
 }

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.rollbar.okhttp;
 
 import com.rollbar.api.payload.data.Level;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -189,6 +190,32 @@ class RollbarOkHttpInterceptorTest {
         verify(recorder).recordNetworkEvent(
                 eq(Level.CRITICAL), eq("GET"),
                 argThat(url -> url.contains("/sensitive") && !url.contains("secret") && !url.contains("email")),
+                eq("500"));
+    }
+
+    @Test
+    void defaultSanitizer_stripsCredentialsAndFragment() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        HttpUrl urlWithCredentials = server.url("/charge")
+                .newBuilder()
+                .username("anyUser")
+                .password("anyPassword")
+                .addQueryParameter("token", "abc")
+                .fragment("section")
+                .build();
+
+        Request request = new Request.Builder().url(urlWithCredentials).build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        verify(recorder).recordNetworkEvent(
+                eq(Level.CRITICAL), eq("GET"),
+                argThat(url -> url.contains("/charge")
+                        && !url.contains("anyUser")
+                        && !url.contains("anyPassword")
+                        && !url.contains("token")
+                        && !url.contains("section")),
                 eq("500"));
     }
 

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -145,4 +145,33 @@ class RollbarOkHttpInterceptorTest {
 
         assertThrows(IOException.class, () -> nullRecorderClient.newCall(request).execute());
     }
+
+    @Test
+    void recorderThrowsOnErrorResponse_responseStillReturned() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        doThrow(new RuntimeException("recorder boom"))
+                .when(recorder)
+                .recordNetworkEvent(any(), any(), any(), any());
+
+        Request request = new Request.Builder().url(server.url("/error")).build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        assertEquals(500, response.code());
+    }
+
+    @Test
+    void recorderThrowsOnConnectionFailure_originalIOExceptionPropagates() {
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+        doThrow(new RuntimeException("recorder boom"))
+                .when(recorder)
+                .recordErrorEvent(any());
+
+        Request request = new Request.Builder().url(server.url("/fail")).build();
+
+        assertThrows(IOException.class, () -> client.newCall(request).execute());
+        verify(recorder).recordErrorEvent(any(IOException.class));
+    }
 }

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -193,6 +193,23 @@ class RollbarOkHttpInterceptorTest {
     }
 
     @Test
+    void customSanitizerThrows_responseStillReturnedAndRecorderNotCalled() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        OkHttpClient throwingClient = new OkHttpClient.Builder()
+                .addInterceptor(new RollbarOkHttpInterceptor(recorder,
+                        url -> { throw new IllegalStateException("bad url"); }))
+                .build();
+
+        Request request = new Request.Builder().url(server.url("/error")).build();
+        Response response = throwingClient.newCall(request).execute();
+        response.close();
+
+        assertEquals(500, response.code());
+        verify(recorder, never()).recordNetworkEvent(any(), any(), any(), any());
+    }
+
+    @Test
     void customSanitizer_isAppliedToUrl() throws IOException {
         server.enqueue(new MockResponse().setResponseCode(500));
 

--- a/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
+++ b/rollbar-okhttp/src/test/java/com/rollbar/okhttp/RollbarOkHttpInterceptorTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 class RollbarOkHttpInterceptorTest {
@@ -173,5 +174,38 @@ class RollbarOkHttpInterceptorTest {
 
         assertThrows(IOException.class, () -> client.newCall(request).execute());
         verify(recorder).recordErrorEvent(any(IOException.class));
+    }
+
+    @Test
+    void defaultSanitizer_stripsQueryParamsFromUrl() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        Request request = new Request.Builder()
+                .url(server.url("/sensitive?token=sk_live_secret&email=user@example.com"))
+                .build();
+        Response response = client.newCall(request).execute();
+        response.close();
+
+        verify(recorder).recordNetworkEvent(
+                eq(Level.CRITICAL), eq("GET"),
+                argThat(url -> url.contains("/sensitive") && !url.contains("secret") && !url.contains("email")),
+                eq("500"));
+    }
+
+    @Test
+    void customSanitizer_isAppliedToUrl() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        OkHttpClient customClient = new OkHttpClient.Builder()
+                .addInterceptor(new RollbarOkHttpInterceptor(recorder, url -> "Updated String"))
+                .build();
+
+        Request request = new Request.Builder()
+                .url(server.url("/path?secret=abc"))
+                .build();
+        Response response = customClient.newCall(request).execute();
+        response.close();
+
+        verify(recorder).recordNetworkEvent(eq(Level.CRITICAL), eq("GET"), eq("Updated String"), eq("500"));
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ include(
     ":rollbar-jakarta-web",
     ":rollbar-log4j2",
     ":rollbar-logback",
+    "rollbar-okhttp",
     ":rollbar-spring-webmvc",
     ":rollbar-spring6-webmvc",
     ":rollbar-spring-boot-webmvc",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,7 @@ include(
     ":rollbar-jakarta-web",
     ":rollbar-log4j2",
     ":rollbar-logback",
-    "rollbar-okhttp",
+    ":rollbar-okhttp",
     ":rollbar-spring-webmvc",
     ":rollbar-spring6-webmvc",
     ":rollbar-spring-boot-webmvc",


### PR DESCRIPTION
## Description of the change

- Add `rollbar-okhttp` module with an OkHttp interceptor that records network telemetry (HTTP errors) and error events (connection failures/timeouts) via Rollbar
- Includes `NetworkTelemetryRecorder` interface for bridging with any Rollbar instance

## Examples

400/500
<img width="1359" height="290" alt="Captura de pantalla 2026-03-24 a la(s) 4 34 01 p  m" src="https://github.com/user-attachments/assets/77bf9eea-234c-4d9b-b258-fc4320f62de4" />

connection error logs the IOException
<img width="577" height="54" alt="Captura de pantalla 2026-03-24 a la(s) 4 36 05 p  m" src="https://github.com/user-attachments/assets/f976a486-4330-494a-9546-b471a59276e7" />



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
