### PR TITLE
[Feat] [SDK-399] Capture logcat output as telemetry events

### DIFF
--- a/rollbar-android/build.gradle.kts
+++ b/rollbar-android/build.gradle.kts
@@ -25,10 +25,6 @@ android {
         }
     }
 
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/rollbar-android/build.gradle.kts
+++ b/rollbar-android/build.gradle.kts
@@ -25,6 +25,10 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/rollbar-android/src/main/java/com/rollbar/android/AndroidConfiguration.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/AndroidConfiguration.java
@@ -1,14 +1,19 @@
 package com.rollbar.android;
 
 import com.rollbar.android.anr.AnrConfiguration;
+import com.rollbar.api.payload.data.Level;
 
 public class AndroidConfiguration {
   private final AnrConfiguration anrConfiguration;
   private final boolean mustCaptureNavigationEvents;
+  private final boolean mustCaptureLogsAsTelemetry;
+  private final Level minimumLogCaptureLevel;
 
   AndroidConfiguration(Builder builder) {
     anrConfiguration = builder.anrConfiguration;
     mustCaptureNavigationEvents = builder.mustCaptureNavigationEvents;
+    mustCaptureLogsAsTelemetry = builder.mustCaptureLogsAsTelemetry;
+    minimumLogCaptureLevel = builder.minimumLogCaptureLevel;
   }
 
   public AnrConfiguration getAnrConfiguration() {
@@ -19,10 +24,20 @@ public class AndroidConfiguration {
     return mustCaptureNavigationEvents;
   }
 
+  public boolean mustCaptureLogsAsTelemetry() {
+    return mustCaptureLogsAsTelemetry;
+  }
+
+  public Level getMinimumLogCaptureLevel() {
+    return minimumLogCaptureLevel;
+  }
+
 
   public static final class Builder {
     private AnrConfiguration anrConfiguration;
     private boolean mustCaptureNavigationEvents = true;
+    private boolean mustCaptureLogsAsTelemetry = false;
+    private Level minimumLogCaptureLevel = Level.WARNING;
 
     public Builder() {
       anrConfiguration = new AnrConfiguration.Builder().build();
@@ -46,6 +61,32 @@ public class AndroidConfiguration {
      */
     public Builder captureNewActivityTelemetryEvents(boolean mustCaptureNavigationEvents) {
       this.mustCaptureNavigationEvents = mustCaptureNavigationEvents;
+      return this;
+    }
+
+    /**
+     * Enable or disable automatic capture of Android log output as telemetry events.
+     * When enabled, logs emitted via {@code android.util.Log} (and any other source written to
+     * logcat from this app's UID, including third-party libraries) at or above the configured
+     * minimum level are recorded as manual telemetry events with
+     * {@link com.rollbar.api.payload.data.Source#CLIENT}.
+     * Default is disabled.
+     * @param mustCaptureLogsAsTelemetry if automatic capture must be enabled or disabled.
+     * @return the builder instance
+     */
+    public Builder captureLogsAsTelemetry(boolean mustCaptureLogsAsTelemetry) {
+      this.mustCaptureLogsAsTelemetry = mustCaptureLogsAsTelemetry;
+      return this;
+    }
+
+    /**
+     * Minimum log level to capture as telemetry when {@link #captureLogsAsTelemetry(boolean)}
+     * is enabled. Default is {@link Level#WARNING}.
+     * @param minimumLogCaptureLevel the minimum level (inclusive) to capture.
+     * @return the builder instance
+     */
+    public Builder minimumLogCaptureLevel(Level minimumLogCaptureLevel) {
+      this.minimumLogCaptureLevel = minimumLogCaptureLevel;
       return this;
     }
 

--- a/rollbar-android/src/main/java/com/rollbar/android/AndroidConfiguration.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/AndroidConfiguration.java
@@ -68,7 +68,7 @@ public class AndroidConfiguration {
      * Enable or disable automatic capture of Android log output as telemetry events.
      * When enabled, logs emitted via {@code android.util.Log} (and any other source written to
      * logcat from this app's UID, including third-party libraries) at or above the configured
-     * minimum level are recorded as manual telemetry events with
+     * minimum level are recorded as log telemetry events with
      * {@link com.rollbar.api.payload.data.Source#CLIENT}.
      * Default is disabled.
      * @param mustCaptureLogsAsTelemetry if automatic capture must be enabled or disabled.

--- a/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
@@ -105,8 +105,8 @@ class LogcatTelemetryCapture {
       } catch (IOException ignored) {
       }
       if (running) {
-        Log.w(Rollbar.TAG, "logcat process exited unexpectedly; resetting capture state");
         stop();
+        Log.w(Rollbar.TAG, "logcat process exited unexpectedly; resetting capture state");
       }
     }
   }

--- a/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
@@ -137,7 +137,7 @@ class LogcatTelemetryCapture {
     }
 
     try {
-      tracker.recordManualEventFor(level, Source.CLIENT, message);
+      tracker.recordLogEventFor(level, Source.CLIENT, message);
     } catch (Exception e) {
       // Never let a broken tracker kill the reader thread.
     }

--- a/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
@@ -1,0 +1,198 @@
+package com.rollbar.android;
+
+import android.util.Log;
+
+import com.rollbar.api.payload.data.Level;
+import com.rollbar.api.payload.data.Source;
+import com.rollbar.notifier.telemetry.TelemetryEventTracker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class LogcatTelemetryCapture {
+
+  // threadtime format: "MM-dd HH:mm:ss.SSS  PID  TID L Tag: message"
+  private static final Pattern LOGCAT_LINE_PATTERN = Pattern.compile(
+      "^\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+\\d+\\s+\\d+\\s+([VDIWEF])\\s+(.+?):\\s(.*)$"
+  );
+
+  private final TelemetryEventTracker tracker;
+  private final Level minimumLevel;
+  private final String selfTag;
+  private final ProcessFactory processFactory;
+
+  private Thread thread;
+  private Process process;
+  private volatile boolean running;
+
+  LogcatTelemetryCapture(
+      TelemetryEventTracker tracker,
+      Level minimumLevel,
+      String selfTag
+  ) {
+    this(tracker, minimumLevel, selfTag, defaultProcessFactory());
+  }
+
+  LogcatTelemetryCapture(
+      TelemetryEventTracker tracker,
+      Level minimumLevel,
+      String selfTag,
+      ProcessFactory processFactory
+  ) {
+    this.tracker = tracker;
+    this.minimumLevel = minimumLevel != null ? minimumLevel : Level.WARNING;
+    this.selfTag = selfTag;
+    this.processFactory = processFactory;
+  }
+
+  synchronized void start() {
+    if (running) {
+      return;
+    }
+    try {
+      this.process = processFactory.start(logcatPriorityFor(this.minimumLevel));
+    } catch (IOException e) {
+      Log.w(Rollbar.TAG, "Failed to start logcat telemetry capture", e);
+      return;
+    }
+    running = true;
+    thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        readLoop();
+      }
+    }, "rollbar-logcat-telemetry");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  synchronized void stop() {
+    if (!running) {
+      return;
+    }
+    running = false;
+    if (process != null) {
+      process.destroy();
+      process = null;
+    }
+    if (thread != null) {
+      thread.interrupt();
+      thread = null;
+    }
+  }
+
+  private void readLoop() {
+    Process currentProcess = this.process;
+    if (currentProcess == null) {
+      return;
+    }
+    BufferedReader reader = new BufferedReader(
+        new InputStreamReader(currentProcess.getInputStream(), Charset.forName("UTF-8")));
+    try {
+      String line;
+      while (running && (line = reader.readLine()) != null) {
+        processLine(line);
+      }
+    } catch (IOException e) {
+      // Process died or was destroyed — expected on stop().
+    } finally {
+      try {
+        reader.close();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  void processLine(String line) {
+    if (line == null) {
+      return;
+    }
+    Matcher matcher = LOGCAT_LINE_PATTERN.matcher(line);
+    if (!matcher.matches()) {
+      return;
+    }
+
+    String priority = matcher.group(1);
+    String tag = matcher.group(2).trim();
+    String message = matcher.group(3);
+
+    if (selfTag != null && selfTag.equals(tag)) {
+      return;
+    }
+
+    Level level = mapPriorityToLevel(priority);
+    if (level == null) {
+      return;
+    }
+    if (level.level() < minimumLevel.level()) {
+      return;
+    }
+
+    try {
+      tracker.recordManualEventFor(level, Source.CLIENT, message);
+    } catch (Exception e) {
+      // Never let a broken tracker kill the reader thread.
+    }
+  }
+
+  static Level mapPriorityToLevel(String priority) {
+    if (priority == null || priority.isEmpty()) {
+      return null;
+    }
+    switch (priority.charAt(0)) {
+      case 'V':
+      case 'D':
+        return Level.DEBUG;
+      case 'I':
+        return Level.INFO;
+      case 'W':
+        return Level.WARNING;
+      case 'E':
+        return Level.ERROR;
+      case 'F':
+        return Level.CRITICAL;
+      default:
+        return null;
+    }
+  }
+
+  static String logcatPriorityFor(Level level) {
+    if (level == null) {
+      return "W";
+    }
+    switch (level) {
+      case DEBUG:
+        return "D";
+      case INFO:
+        return "I";
+      case WARNING:
+        return "W";
+      case ERROR:
+        return "E";
+      case CRITICAL:
+        return "F";
+      default:
+        return "W";
+    }
+  }
+
+  interface ProcessFactory {
+    Process start(String priorityFilter) throws IOException;
+  }
+
+  private static ProcessFactory defaultProcessFactory() {
+    return new ProcessFactory() {
+      @Override
+      public Process start(String priorityFilter) throws IOException {
+        return new ProcessBuilder(
+            "logcat", "-v", "threadtime", "*:" + priorityFilter)
+            .redirectErrorStream(true)
+            .start();
+      }
+    };
+  }
+}

--- a/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
@@ -193,7 +193,7 @@ class LogcatTelemetryCapture {
       @Override
       public Process start(String priorityFilter) throws IOException {
         return new ProcessBuilder(
-            "logcat", "-v", "threadtime", "*:" + priorityFilter)
+            "logcat", "-v", "threadtime", "-T", "1", "*:" + priorityFilter)
             .redirectErrorStream(true)
             .start();
       }

--- a/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
@@ -166,7 +166,7 @@ class LogcatTelemetryCapture {
     }
     switch (level) {
       case DEBUG:
-        return "D";
+        return "V";
       case INFO:
         return "I";
       case WARNING:

--- a/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/LogcatTelemetryCapture.java
@@ -104,6 +104,10 @@ class LogcatTelemetryCapture {
         reader.close();
       } catch (IOException ignored) {
       }
+      if (running) {
+        Log.w(Rollbar.TAG, "logcat process exited unexpectedly; resetting capture state");
+        stop();
+      }
     }
   }
 

--- a/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/Rollbar.java
@@ -67,6 +67,7 @@ public class Rollbar implements Closeable {
   private final ConnectionAwareSenderFailureStrategy senderFailureStrategy;
 
   private com.rollbar.notifier.Rollbar rollbar;
+  private LogcatTelemetryCapture logcatTelemetryCapture;
   private static Rollbar notifier;
 
   private final int versionCode;
@@ -236,6 +237,7 @@ public class Rollbar implements Closeable {
       if (androidConfiguration != null) {
         initAnrDetector(context, androidConfiguration);
         initAutomaticCaptureOfNavigationTelemetryEvents(context, androidConfiguration);
+        initAutomaticCaptureOfLogTelemetryEvents(androidConfiguration);
       }
     }
 
@@ -277,12 +279,21 @@ public class Rollbar implements Closeable {
       AndroidConfiguration androidConfiguration = makeDefaultAndroidConfiguration();
       initAnrDetector(context, androidConfiguration);
       initAutomaticCaptureOfNavigationTelemetryEvents(context, androidConfiguration);
+      initAutomaticCaptureOfLogTelemetryEvents(androidConfiguration);
     }
     return notifier;
   }
 
   @Override
   public void close() throws IOException {
+    if (logcatTelemetryCapture != null) {
+      try {
+        logcatTelemetryCapture.stop();
+      } catch (Exception e) {
+        Log.w(TAG, "Error stopping logcat telemetry capture", e);
+      }
+      logcatTelemetryCapture = null;
+    }
     if (rollbar != null) {
       try {
         rollbar.close(false);
@@ -1200,6 +1211,31 @@ public class Rollbar implements Closeable {
       Application application = (Application) appContext;
       application.registerActivityLifecycleCallbacks(new TelemetryNavigationCallbacks(telemetryEventTracker));
     }
+  }
+
+  private static void initAutomaticCaptureOfLogTelemetryEvents(
+      AndroidConfiguration androidConfiguration
+  ) {
+    if (!androidConfiguration.mustCaptureLogsAsTelemetry()) {
+      return;
+    }
+
+    com.rollbar.notifier.Rollbar rollbarNotifier = notifier.rollbar;
+    if (rollbarNotifier == null) {
+      return;
+    }
+
+    TelemetryEventTracker telemetryEventTracker = rollbarNotifier.getTelemetryEventTracker();
+    if (telemetryEventTracker == null) {
+      return;
+    }
+
+    LogcatTelemetryCapture logcatTelemetryCapture = new LogcatTelemetryCapture(
+        telemetryEventTracker,
+        androidConfiguration.getMinimumLogCaptureLevel(),
+        TAG);
+    logcatTelemetryCapture.start();
+    notifier.logcatTelemetryCapture = logcatTelemetryCapture;
   }
 
   private String loadAccessTokenFromManifest(Context context) throws NameNotFoundException {

--- a/rollbar-android/src/main/java/com/rollbar/android/notifier/sender/ConnectivityDetector.java
+++ b/rollbar-android/src/main/java/com/rollbar/android/notifier/sender/ConnectivityDetector.java
@@ -13,6 +13,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.util.Log;
+import com.rollbar.android.Rollbar;
 import com.rollbar.notifier.util.ObjectsUtils;
 
 import java.io.Closeable;
@@ -46,7 +47,7 @@ class ConnectivityDetector implements Closeable {
       String message = "This application is missing the " +
               "android.permission.ACCESS_NETWORK_STATE permission. The Rollbar notifier " +
               "will *not* be able to detect when the network is unavailable.";
-      Log.w(ConnectivityDetector.class.getCanonicalName(), message);
+      Log.w(Rollbar.TAG, message);
     }
   }
 

--- a/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
@@ -1,0 +1,147 @@
+package com.rollbar.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.rollbar.api.payload.data.Level;
+import com.rollbar.api.payload.data.Source;
+import com.rollbar.notifier.telemetry.TelemetryEventTracker;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class LogcatTelemetryCaptureTest {
+
+  private TelemetryEventTracker tracker;
+
+  @Before
+  public void setUp() {
+    tracker = mock(TelemetryEventTracker.class);
+  }
+
+  @Test
+  public void mapPriorityToLevel_knownPriorities() {
+    assertEquals(Level.DEBUG, LogcatTelemetryCapture.mapPriorityToLevel("V"));
+    assertEquals(Level.DEBUG, LogcatTelemetryCapture.mapPriorityToLevel("D"));
+    assertEquals(Level.INFO, LogcatTelemetryCapture.mapPriorityToLevel("I"));
+    assertEquals(Level.WARNING, LogcatTelemetryCapture.mapPriorityToLevel("W"));
+    assertEquals(Level.ERROR, LogcatTelemetryCapture.mapPriorityToLevel("E"));
+    assertEquals(Level.CRITICAL, LogcatTelemetryCapture.mapPriorityToLevel("F"));
+  }
+
+  @Test
+  public void mapPriorityToLevel_unknownReturnsNull() {
+    assertNull(LogcatTelemetryCapture.mapPriorityToLevel("X"));
+    assertNull(LogcatTelemetryCapture.mapPriorityToLevel(""));
+    assertNull(LogcatTelemetryCapture.mapPriorityToLevel(null));
+  }
+
+  @Test
+  public void logcatPriorityFor_levels() {
+    assertEquals("D", LogcatTelemetryCapture.logcatPriorityFor(Level.DEBUG));
+    assertEquals("I", LogcatTelemetryCapture.logcatPriorityFor(Level.INFO));
+    assertEquals("W", LogcatTelemetryCapture.logcatPriorityFor(Level.WARNING));
+    assertEquals("E", LogcatTelemetryCapture.logcatPriorityFor(Level.ERROR));
+    assertEquals("F", LogcatTelemetryCapture.logcatPriorityFor(Level.CRITICAL));
+    assertEquals("W", LogcatTelemetryCapture.logcatPriorityFor(null));
+  }
+
+  @Test
+  public void processLine_recordsWarningAtThreshold() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: warn message");
+
+    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn message"));
+  }
+
+  @Test
+  public void processLine_recordsErrorAboveThreshold() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 E MyTag: boom");
+
+    verify(tracker).recordManualEventFor(eq(Level.ERROR), eq(Source.CLIENT), eq("boom"));
+  }
+
+  @Test
+  public void processLine_skipsBelowThreshold() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 I MyTag: info message");
+    capture.processLine("04-20 12:34:56.789  1234  5678 D MyTag: debug message");
+
+    verifyNoInteractions(tracker);
+  }
+
+  @Test
+  public void processLine_skipsSelfTag() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 W Rollbar: recursion risk");
+
+    verifyNoInteractions(tracker);
+  }
+
+  @Test
+  public void processLine_skipsUnparseable() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("--------- beginning of main");
+    capture.processLine("");
+    capture.processLine(null);
+
+    verifyNoInteractions(tracker);
+  }
+
+  @Test
+  public void processLine_trimsTag() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 W   MyTag  : message");
+
+    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("message"));
+  }
+
+  @Test
+  public void processLine_trackerThrow_doesNotPropagate() {
+    doThrow(new RuntimeException("tracker boom"))
+        .when(tracker).recordManualEventFor(any(), any(), any());
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: message");
+
+    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("message"));
+  }
+
+  @Test
+  public void processLine_messageWithColon_preserved() {
+    LogcatTelemetryCapture capture = newCapture(Level.WARNING);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: key: value");
+
+    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("key: value"));
+  }
+
+  @Test
+  public void processLine_defaultsToWarningWhenMinLevelIsNull() {
+    LogcatTelemetryCapture capture = newCapture(null);
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 I MyTag: info");
+    verify(tracker, never()).recordManualEventFor(any(), any(), any());
+
+    capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: warn");
+    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn"));
+  }
+
+  private LogcatTelemetryCapture newCapture(Level minLevel) {
+    return new LogcatTelemetryCapture(tracker, minLevel, "Rollbar");
+  }
+}

--- a/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
@@ -63,7 +63,7 @@ public class LogcatTelemetryCaptureTest {
 
     capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: warn message");
 
-    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn message"));
+    verify(tracker).recordLogEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn message"));
   }
 
   @Test
@@ -72,7 +72,7 @@ public class LogcatTelemetryCaptureTest {
 
     capture.processLine("04-20 12:34:56.789  1234  5678 E MyTag: boom");
 
-    verify(tracker).recordManualEventFor(eq(Level.ERROR), eq(Source.CLIENT), eq("boom"));
+    verify(tracker).recordLogEventFor(eq(Level.ERROR), eq(Source.CLIENT), eq("boom"));
   }
 
   @Test
@@ -111,18 +111,18 @@ public class LogcatTelemetryCaptureTest {
 
     capture.processLine("04-20 12:34:56.789  1234  5678 W   MyTag  : message");
 
-    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("message"));
+    verify(tracker).recordLogEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("message"));
   }
 
   @Test
   public void processLine_trackerThrow_doesNotPropagate() {
     doThrow(new RuntimeException("tracker boom"))
-        .when(tracker).recordManualEventFor(any(), any(), any());
+        .when(tracker).recordLogEventFor(any(), any(), any());
     LogcatTelemetryCapture capture = newCapture(Level.WARNING);
 
     capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: message");
 
-    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("message"));
+    verify(tracker).recordLogEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("message"));
   }
 
   @Test
@@ -131,7 +131,7 @@ public class LogcatTelemetryCaptureTest {
 
     capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: key: value");
 
-    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("key: value"));
+    verify(tracker).recordLogEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("key: value"));
   }
 
   @Test
@@ -139,10 +139,10 @@ public class LogcatTelemetryCaptureTest {
     LogcatTelemetryCapture capture = newCapture(null);
 
     capture.processLine("04-20 12:34:56.789  1234  5678 I MyTag: info");
-    verify(tracker, never()).recordManualEventFor(any(), any(), any());
+    verify(tracker, never()).recordLogEventFor(any(), any(), any());
 
     capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: warn");
-    verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn"));
+    verify(tracker).recordLogEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn"));
   }
 
   @Test

--- a/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import com.rollbar.api.payload.data.Level;
 import com.rollbar.api.payload.data.Source;
@@ -16,6 +17,9 @@ import com.rollbar.notifier.telemetry.TelemetryEventTracker;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class LogcatTelemetryCaptureTest {
 
@@ -139,6 +143,28 @@ public class LogcatTelemetryCaptureTest {
 
     capture.processLine("04-20 12:34:56.789  1234  5678 W MyTag: warn");
     verify(tracker).recordManualEventFor(eq(Level.WARNING), eq(Source.CLIENT), eq("warn"));
+  }
+
+  @Test
+  public void start_afterUnexpectedProcessDeath_allowsRestartWithNewProcess() throws Exception {
+    Process dyingProcess = mock(Process.class);
+    when(dyingProcess.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+
+    AtomicInteger factoryCallCount = new AtomicInteger(0);
+    LogcatTelemetryCapture.ProcessFactory factory = priority -> {
+      factoryCallCount.incrementAndGet();
+      return dyingProcess;
+    };
+
+    LogcatTelemetryCapture capture = new LogcatTelemetryCapture(tracker, Level.WARNING, "Rollbar", factory);
+    capture.start();
+
+    // Allow the reader thread to detect EOF and reset running=false via stop()
+    Thread.sleep(200);
+
+    capture.start();
+
+    assertEquals(2, factoryCallCount.get());
   }
 
   private LogcatTelemetryCapture newCapture(Level minLevel) {

--- a/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
@@ -45,7 +45,7 @@ public class LogcatTelemetryCaptureTest {
 
   @Test
   public void logcatPriorityFor_levels() {
-    assertEquals("D", LogcatTelemetryCapture.logcatPriorityFor(Level.DEBUG));
+    assertEquals("V", LogcatTelemetryCapture.logcatPriorityFor(Level.DEBUG));
     assertEquals("I", LogcatTelemetryCapture.logcatPriorityFor(Level.INFO));
     assertEquals("W", LogcatTelemetryCapture.logcatPriorityFor(Level.WARNING));
     assertEquals("E", LogcatTelemetryCapture.logcatPriorityFor(Level.ERROR));

--- a/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
+++ b/rollbar-android/src/test/java/com/rollbar/android/LogcatTelemetryCaptureTest.java
@@ -159,10 +159,12 @@ public class LogcatTelemetryCaptureTest {
     LogcatTelemetryCapture capture = new LogcatTelemetryCapture(tracker, Level.WARNING, "Rollbar", factory);
     capture.start();
 
-    // Allow the reader thread to detect EOF and reset running=false via stop()
-    Thread.sleep(200);
-
-    capture.start();
+    // Poll start() until the reader thread detects EOF and resets running=false
+    long deadline = System.currentTimeMillis() + 2000;
+    while (factoryCallCount.get() < 2 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10);
+      capture.start();
+    }
 
     assertEquals(2, factoryCallCount.get());
   }

--- a/rollbar-java/src/main/java/com/rollbar/notifier/telemetry/RollbarTelemetryEventTracker.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/telemetry/RollbarTelemetryEventTracker.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * buffer. When the configured maximum capacity is reached, the oldest events
  * are discarded to make room for new ones.
  *
- * <p>Recorded events are returned and cleared when {@link #dump()} is called.
+ * <p>Recorded events are returned when {@link #getAll()} is called.
  */
 public class RollbarTelemetryEventTracker implements TelemetryEventTracker {
   public static final int MAXIMUM_CAPACITY_FOR_TELEMETRY_EVENTS = 100;

--- a/rollbar-java/src/main/java/com/rollbar/notifier/telemetry/TelemetryEventTracker.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/telemetry/TelemetryEventTracker.java
@@ -10,8 +10,8 @@ import java.util.List;
 /**
  * Collects and manages telemetry events that provide additional runtime
  * context for error and message payloads.
- * Telemetry events are typically buffered and cleared after they are
- * {@link #dump() dumped}.
+ * Telemetry events are typically buffered and retrieved via
+ * {@link #getAll()}.
  */
 public interface TelemetryEventTracker {
 


### PR DESCRIPTION
## Description of the change

Automatically captures Android log output and records it as telemetry events, giving Rollbar users richer context in their telemetry trail at the time an error occurs.                                                                
   
  How to enable                                                                                                                                                                                                                          
                  
  Pass `captureLogsAsTelemetry(true)` when building your AndroidConfiguration:                                                                                                                                                             
  
```java
  AndroidConfiguration config = new AndroidConfiguration.Builder(accessToken)
      .captureLogsAsTelemetry(true)                                                                                                                                                                                                      
      .build();
                                                                                                                                                                                                                                         
  Rollbar.init(context, config);                                                                                                                                                                                                         
``` 
  When enabled, log lines emitted via android.util.Log (and any other source writing to logcat from the app's UID, including third-party libraries) at or above the configured minimum level are recorded as TelemetryType.LOG events    
  with Source.CLIENT.
                                                                                                                                                                                                                                         
  Configuring the minimum log level

  By default only WARNING and above are captured. Use logTelemetryMinimumLevel to capture more or fewer entries:                                                                                                                         

### Capture INFO and above
```java                                                                                                                                                                                                      
  AndroidConfiguration config = new AndroidConfiguration.Builder(accessToken)
      .captureLogsAsTelemetry(true)
      .logTelemetryMinimumLevel(Level.INFO)                                                                                                                                                                                              
      .build();
```
### Capture only errors
```java
  AndroidConfiguration config = new AndroidConfiguration.Builder(accessToken)
      .captureLogsAsTelemetry(true)                                                                                                                                                                                                      
      .logTelemetryMinimumLevel(Level.ERROR)
      .build();                                                                                                                                                                                                                          
```
### Supported levels (mapped from logcat priorities):                                                                                                                                                                                      
| Logcat priority | Rollbar level |
|-----------------|---------------|
| V, D            | DEBUG         |
| I               | INFO          |
| W               | WARNING       |
| E               | ERROR         |
| F               | CRITICAL      |                                                                                                                                                                                         

###  Notes                                                                                                                                                                                                                                  
                  
  - The feature is disabled by default and must be explicitly opted in.                                                                                                                                                                  
  - Capture stops automatically when Rollbar.close() is called.
  - Rollbar's own internal log output is excluded from captured telemetry.

<img width="1433" height="401" alt="Captura de pantalla 2026-05-01 a la(s) 4 04 37 p  m" src="https://github.com/user-attachments/assets/bb99ca24-fc36-4f6b-ac0f-b177d3c8769b" />



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
