### PR TITLE
[Feat][SDK-594] Compress payload and update payload max size to 1mb

### DIFF
--- a/rollbar-java/src/integTest/java/com/rollbar/notifier/RollbarITest.java
+++ b/rollbar-java/src/integTest/java/com/rollbar/notifier/RollbarITest.java
@@ -352,7 +352,7 @@ public class RollbarITest {
     assertThat(frames, hasSize(20));
 
     assertThat(PayloadTruncator.sizeInBytes(payloadJsonString),
-        lessThanOrEqualTo(512 * 1024));
+        lessThanOrEqualTo(1024 * 1024));
   }
 
   protected Sender buildSender(String url, String accessToken, Proxy proxy) {

--- a/rollbar-java/src/main/java/com/rollbar/notifier/RollbarBase.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/RollbarBase.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public abstract class RollbarBase<RESULT, C extends CommonConfig> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RollbarBase.class);
-  private static final int MAX_PAYLOAD_SIZE_BYTES = 512 * 1024; // 512kb
+  private static final int MAX_PAYLOAD_SIZE_BYTES = 1024 * 1024; // 1mb
 
   protected BodyFactory bodyFactory;
   protected PayloadTruncator payloadTruncator;

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/CommonConfig.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/CommonConfig.java
@@ -212,6 +212,15 @@ public interface CommonConfig {
    */
   boolean truncateLargePayloads();
 
+  /**
+   * <p>
+   * If set to true (the default), payloads are gzip-compressed before sending.
+   * Set to false to send uncompressed JSON.
+   * </p>
+   * @return true to compress payloads, false otherwise.
+   */
+  boolean compressPayload();
+
   int maximumTelemetryData();
 
   TelemetryEventTracker telemetryEventTracker();

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/CommonConfig.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/CommonConfig.java
@@ -219,7 +219,9 @@ public interface CommonConfig {
    * </p>
    * @return true to compress payloads, false otherwise.
    */
-  boolean compressPayload();
+  default boolean compressPayload() {
+    return true;
+  }
 
   int maximumTelemetryData();
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/config/ConfigBuilder.java
@@ -87,6 +87,8 @@ public class ConfigBuilder {
 
   protected boolean truncateLargePayloads;
 
+  protected boolean compressPayload;
+
   private int maximumTelemetryData =
       RollbarTelemetryEventTracker.MAXIMUM_CAPACITY_FOR_TELEMETRY_EVENTS;
 
@@ -101,6 +103,7 @@ public class ConfigBuilder {
     this.accessToken = accessToken;
     this.handleUncaughtErrors = true;
     this.enabled = true;
+    this.compressPayload = true;
     this.defaultLevels = new DefaultLevels();
   }
 
@@ -136,6 +139,7 @@ public class ConfigBuilder {
     this.appPackages = config.appPackages();
     this.defaultLevels = new DefaultLevels(config);
     this.truncateLargePayloads = config.truncateLargePayloads();
+    this.compressPayload = config.compressPayload();
     this.maximumTelemetryData = config.maximumTelemetryData();
     this.telemetryEventTracker = config.telemetryEventTracker();
   }
@@ -482,6 +486,18 @@ public class ConfigBuilder {
 
   /**
    * <p>
+   * If set to false, payloads will not be gzip-compressed before sending. Default: true.
+   * </p>
+   * @param compress true to gzip-compress payloads.
+   * @return the builder instance.
+   */
+  public ConfigBuilder compressPayload(boolean compress) {
+    this.compressPayload = compress;
+    return this;
+  }
+
+  /**
+   * <p>
    * Maximum Telemetry events sent in a payload, only for the default TelemetryEventTracker, if
    * a custom implementation is used this value will be ignored. Default is
    * {@value RollbarTelemetryEventTracker#MAXIMUM_CAPACITY_FOR_TELEMETRY_EVENTS}.
@@ -526,7 +542,8 @@ public class ConfigBuilder {
       SyncSender.Builder innerSender =
           new SyncSender.Builder(this.endpoint)
           .accessToken(accessToken)
-          .proxy(proxy);
+          .proxy(proxy)
+          .compressPayload(this.compressPayload);
       if (this.jsonSerializer != null) {
         innerSender.jsonSerializer(this.jsonSerializer);
       }
@@ -601,6 +618,8 @@ public class ConfigBuilder {
 
     private final boolean truncateLargePayloads;
 
+    private final boolean compressPayload;
+
     private final int maximumTelemetryData;
 
     private final TelemetryEventTracker telemetryEventTracker;
@@ -637,6 +656,7 @@ public class ConfigBuilder {
       this.enabled = builder.enabled;
       this.defaultLevels = builder.defaultLevels;
       this.truncateLargePayloads = builder.truncateLargePayloads;
+      this.compressPayload = builder.compressPayload;
       this.maximumTelemetryData = builder.maximumTelemetryData;
       this.telemetryEventTracker = builder.telemetryEventTracker;
     }
@@ -784,6 +804,11 @@ public class ConfigBuilder {
     @Override
     public boolean truncateLargePayloads() {
       return this.truncateLargePayloads;
+    }
+
+    @Override
+    public boolean compressPayload() {
+      return this.compressPayload;
     }
 
     @Override

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
@@ -12,10 +12,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.util.zip.GZIPOutputStream;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Synchronous implementation of the {@link Sender sender}.

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.util.zip.GZIPOutputStream;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
@@ -33,11 +34,14 @@ public class SyncSender extends AbstractSender {
 
   private final Proxy proxy;
 
+  private final boolean compressPayload;
+
   SyncSender(Builder builder) {
     this.url = builder.url;
     this.jsonSerializer = builder.jsonSerializer;
     this.accessToken = builder.accessToken;
     this.proxy = builder.proxy != null ? builder.proxy : Proxy.NO_PROXY;
+    this.compressPayload = builder.compressPayload;
   }
 
   @Override
@@ -69,6 +73,9 @@ public class SyncSender extends AbstractSender {
     connection.setRequestProperty("Accept-Charset", UTF_8);
     connection.setRequestProperty("Content-Type", "application/json; charset=" + UTF_8);
     connection.setRequestProperty("Accept", "application/json");
+    if (compressPayload) {
+      connection.setRequestProperty("Content-Encoding", "gzip");
+    }
     connection.setDoOutput(true);
     connection.setRequestMethod("POST");
 
@@ -78,7 +85,9 @@ public class SyncSender extends AbstractSender {
   private void sendJson(HttpURLConnection connection, byte[] bytes) throws IOException {
     OutputStream out = null;
     try {
-      out = connection.getOutputStream();
+      out = compressPayload
+          ? new GZIPOutputStream(connection.getOutputStream())
+          : connection.getOutputStream();
       out.write(bytes, 0, bytes.length);
     } catch (IOException e) {
       throw e;
@@ -130,6 +139,8 @@ public class SyncSender extends AbstractSender {
     private String accessToken;
 
     private Proxy proxy;
+
+    private boolean compressPayload = true;
 
     public Builder() {
       this(DEFAULT_API_ENDPOINT);
@@ -192,6 +203,16 @@ public class SyncSender extends AbstractSender {
      */
     public Builder proxy(Proxy proxy) {
       this.proxy = proxy;
+      return this;
+    }
+
+    /**
+     * Whether to gzip-compress payloads before sending. Default: true.
+     * @param compress true to enable compression.
+     * @return the builder instance.
+     */
+    public Builder compressPayload(boolean compress) {
+      this.compressPayload = compress;
       return this;
     }
 

--- a/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
+++ b/rollbar-java/src/main/java/com/rollbar/notifier/sender/SyncSender.java
@@ -85,12 +85,14 @@ public class SyncSender extends AbstractSender {
   private void sendJson(HttpURLConnection connection, byte[] bytes) throws IOException {
     OutputStream out = null;
     try {
-      out = compressPayload
-          ? new GZIPOutputStream(connection.getOutputStream())
-          : connection.getOutputStream();
+      OutputStream raw = connection.getOutputStream();
+      try {
+        out = compressPayload ? new GZIPOutputStream(raw) : raw;
+      } catch (IOException e) {
+        ObjectsUtils.close(raw);
+        throw e;
+      }
       out.write(bytes, 0, bytes.length);
-    } catch (IOException e) {
-      throw e;
     } finally {
       ObjectsUtils.close(out);
     }

--- a/rollbar-java/src/test/java/com/rollbar/notifier/sender/SyncSenderTest.java
+++ b/rollbar-java/src/test/java/com/rollbar/notifier/sender/SyncSenderTest.java
@@ -17,9 +17,11 @@ import com.rollbar.notifier.sender.listener.SenderListener;
 import com.rollbar.notifier.sender.result.Response;
 import com.rollbar.notifier.sender.result.Result;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URL;
@@ -76,6 +78,7 @@ public class SyncSenderTest {
     sut = new SyncSender.Builder()
         .url(url)
         .jsonSerializer(serializer)
+        .compressPayload(false)
         .build();
     sut.addListener(listener);
   }
@@ -196,6 +199,57 @@ public class SyncSenderTest {
     verifyHttp();
     verify(connection).getInputStream();
     verify(listener).onResponse(payload, expectedResponse);
+  }
+
+  @Test
+  public void shouldSendGzipEncodedPayloadWhenCompressionEnabled() throws Exception {
+    ByteArrayOutputStream capturedBytes = new ByteArrayOutputStream();
+    when(url.openConnection(eq(Proxy.NO_PROXY))).thenReturn(connection);
+    when(connection.getOutputStream()).thenReturn(capturedBytes);
+
+    int responseCode = 200;
+    String responseJson = "simulated_response_json";
+    when(connection.getResponseCode()).thenReturn(responseCode);
+    when(connection.getInputStream())
+        .thenReturn(new ByteArrayInputStream(responseJson.getBytes(UTF_8)));
+    when(serializer.resultFrom(responseJson)).thenReturn(result);
+
+    SyncSender compressingSut = new SyncSender.Builder()
+        .url(url)
+        .jsonSerializer(serializer)
+        .compressPayload(true)
+        .build();
+
+    compressingSut.send(payload);
+
+    verify(connection).setRequestProperty("Content-Encoding", "gzip");
+
+    GZIPInputStream gzipIn = new GZIPInputStream(
+        new ByteArrayInputStream(capturedBytes.toByteArray()));
+    ByteArrayOutputStream decompressedBytes = new ByteArrayOutputStream();
+    byte[] buf = new byte[1024];
+    int n;
+    while ((n = gzipIn.read(buf)) != -1) {
+      decompressedBytes.write(buf, 0, n);
+    }
+    String decompressed = decompressedBytes.toString(UTF_8);
+    assertThat(decompressed, is(PAYLOAD_JSON));
+  }
+
+  @Test
+  public void shouldNotSetContentEncodingWhenCompressionDisabled() throws Exception {
+    int responseCode = 200;
+    String responseJson = "simulated_response_json";
+    when(connection.getResponseCode()).thenReturn(responseCode);
+    when(connection.getInputStream())
+        .thenReturn(new ByteArrayInputStream(responseJson.getBytes(UTF_8)));
+    when(serializer.resultFrom(responseJson)).thenReturn(result);
+
+    sut.send(payload);
+
+    verify(connection, org.mockito.Mockito.never())
+        .setRequestProperty(org.mockito.ArgumentMatchers.eq("Content-Encoding"),
+            org.mockito.ArgumentMatchers.anyString());
   }
 
   private void verifyHttp() throws Exception {

--- a/rollbar-reactive-streams-reactor/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ReactorAsyncHttpClient.java
+++ b/rollbar-reactive-streams-reactor/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ReactorAsyncHttpClient.java
@@ -1,12 +1,16 @@
 package com.rollbar.reactivestreams.notifier.sender.http;
 
+import com.rollbar.notifier.sender.SyncSender;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Map;
+import java.util.zip.GZIPOutputStream;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -47,8 +51,8 @@ public class ReactorAsyncHttpClient implements AsyncHttpClient {
   public Publisher<AsyncHttpResponse> send(AsyncHttpRequest httpRequest) {
 
     ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
-    if (httpRequest.getBodyBytes() != null) {
-      buffer.writeBytes(httpRequest.getBodyBytes());
+    if (httpRequest.isCompressionRequested()) {
+      buffer.writeBytes(compress(httpRequest.getBody()));
     } else {
       buffer.writeCharSequence(httpRequest.getBody(), StandardCharsets.UTF_8);
     }
@@ -58,6 +62,9 @@ public class ReactorAsyncHttpClient implements AsyncHttpClient {
         .headers(entries -> {
           for (Map.Entry<String, String> header : httpRequest.getHeaders()) {
             entries.add(header.getKey(), header.getValue());
+          }
+          if (httpRequest.isCompressionRequested()) {
+            entries.add("Content-Encoding", "gzip");
           }
         })
         .post()
@@ -141,6 +148,18 @@ public class ReactorAsyncHttpClient implements AsyncHttpClient {
         return ProxyProvider.Proxy.SOCKS5;
       default:
         throw new IllegalArgumentException("Unknown proxy type " + proxy.type());
+    }
+  }
+
+  private static byte[] compress(String json) {
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      GZIPOutputStream gzip = new GZIPOutputStream(baos);
+      gzip.write(json.getBytes(SyncSender.UTF_8));
+      gzip.close();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to gzip-compress payload", e);
     }
   }
 

--- a/rollbar-reactive-streams-reactor/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ReactorAsyncHttpClient.java
+++ b/rollbar-reactive-streams-reactor/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ReactorAsyncHttpClient.java
@@ -47,7 +47,11 @@ public class ReactorAsyncHttpClient implements AsyncHttpClient {
   public Publisher<AsyncHttpResponse> send(AsyncHttpRequest httpRequest) {
 
     ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
-    buffer.writeCharSequence(httpRequest.getBody(), StandardCharsets.UTF_8);
+    if (httpRequest.getBodyBytes() != null) {
+      buffer.writeBytes(httpRequest.getBodyBytes());
+    } else {
+      buffer.writeCharSequence(httpRequest.getBody(), StandardCharsets.UTF_8);
+    }
     Mono<ByteBuf> buf = Mono.just(buffer);
 
     return httpClient

--- a/rollbar-reactive-streams-reactor/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ReactorAsyncHttpClient.java
+++ b/rollbar-reactive-streams-reactor/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ReactorAsyncHttpClient.java
@@ -51,10 +51,15 @@ public class ReactorAsyncHttpClient implements AsyncHttpClient {
   public Publisher<AsyncHttpResponse> send(AsyncHttpRequest httpRequest) {
 
     ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
-    if (httpRequest.isCompressionRequested()) {
-      buffer.writeBytes(compress(httpRequest.getBody()));
-    } else {
-      buffer.writeCharSequence(httpRequest.getBody(), StandardCharsets.UTF_8);
+    try {
+      if (httpRequest.isCompressionRequested()) {
+        buffer.writeBytes(compress(httpRequest.getBody()));
+      } else {
+        buffer.writeCharSequence(httpRequest.getBody(), StandardCharsets.UTF_8);
+      }
+    } catch (Throwable t) {
+      buffer.release();
+      throw t;
     }
     Mono<ByteBuf> buf = Mono.just(buffer);
 
@@ -154,9 +159,9 @@ public class ReactorAsyncHttpClient implements AsyncHttpClient {
   private static byte[] compress(String json) {
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      GZIPOutputStream gzip = new GZIPOutputStream(baos);
-      gzip.write(json.getBytes(SyncSender.UTF_8));
-      gzip.close();
+      try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+        gzip.write(json.getBytes(SyncSender.UTF_8));
+      }
       return baos.toByteArray();
     } catch (IOException e) {
       throw new RuntimeException("Failed to gzip-compress payload", e);

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/config/ConfigBuilder.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/config/ConfigBuilder.java
@@ -61,6 +61,7 @@ public final class ConfigBuilder {
   private boolean enabled;
   private DefaultLevels defaultLevels;
   private boolean truncateLargePayloads;
+  private boolean compressPayload;
   private int maximumTelemetryData =
       RollbarTelemetryEventTracker.MAXIMUM_CAPACITY_FOR_TELEMETRY_EVENTS;
   private TelemetryEventTracker telemetryEventTracker;
@@ -74,6 +75,7 @@ public final class ConfigBuilder {
     this.accessToken = accessToken;
     this.handleUncaughtErrors = true;
     this.enabled = true;
+    this.compressPayload = true;
     this.defaultLevels = new DefaultLevels();
   }
 
@@ -106,6 +108,7 @@ public final class ConfigBuilder {
     this.appPackages = config.appPackages();
     this.defaultLevels = new DefaultLevels(config);
     this.truncateLargePayloads = config.truncateLargePayloads();
+    this.compressPayload = config.compressPayload();
     this.maximumTelemetryData = config.maximumTelemetryData();
     this.telemetryEventTracker = config.telemetryEventTracker();
   }
@@ -471,6 +474,18 @@ public final class ConfigBuilder {
 
   /**
    * <p>
+   * If set to false, payloads will not be gzip-compressed before sending. Default: true.
+   * </p>
+   * @param compress true to gzip-compress payloads.
+   * @return the builder instance.
+   */
+  public ConfigBuilder compressPayload(boolean compress) {
+    this.compressPayload = compress;
+    return this;
+  }
+
+  /**
+   * <p>
    * Maximum Telemetry events sent in a payload, only for the default TelemetryEventTracker, if
    * a custom implementation is used this value will be ignored. Default is
    * {@value RollbarTelemetryEventTracker#MAXIMUM_CAPACITY_FOR_TELEMETRY_EVENTS}.
@@ -517,7 +532,8 @@ public final class ConfigBuilder {
         httpClient = AsyncHttpClientFactory.defaultClient();
       }
       AsyncSender.Builder senderBuilder = new AsyncSender.Builder(httpClient, this.endpoint)
-              .accessToken(accessToken);
+              .accessToken(accessToken)
+              .compressPayload(this.compressPayload);
 
       if (this.jsonSerializer != null) {
         senderBuilder.jsonSerializer(this.jsonSerializer);
@@ -565,6 +581,7 @@ public final class ConfigBuilder {
     private final DefaultLevels defaultLevels;
     private final JsonSerializer jsonSerializer;
     private final boolean truncateLargePayloads;
+    private final boolean compressPayload;
     private final int maximumTelemetryData;
     private final TelemetryEventTracker telemetryEventTracker;
 
@@ -599,6 +616,7 @@ public final class ConfigBuilder {
       this.defaultLevels = builder.defaultLevels;
       this.jsonSerializer = builder.jsonSerializer;
       this.truncateLargePayloads = builder.truncateLargePayloads;
+      this.compressPayload = builder.compressPayload;
       this.maximumTelemetryData = builder.maximumTelemetryData;
       this.telemetryEventTracker = builder.telemetryEventTracker;
     }
@@ -741,6 +759,11 @@ public final class ConfigBuilder {
     @Override
     public boolean truncateLargePayloads() {
       return truncateLargePayloads;
+    }
+
+    @Override
+    public boolean compressPayload() {
+      return compressPayload;
     }
 
     @Override

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/AsyncSender.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/AsyncSender.java
@@ -10,9 +10,12 @@ import com.rollbar.reactivestreams.Utils;
 import com.rollbar.reactivestreams.notifier.sender.http.AsyncHttpClient;
 import com.rollbar.reactivestreams.notifier.sender.http.AsyncHttpRequest;
 import com.rollbar.reactivestreams.notifier.sender.http.AsyncHttpResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedHashMap;
+import java.util.zip.GZIPOutputStream;
 import org.reactivestreams.Publisher;
 
 /**
@@ -23,12 +26,14 @@ public class AsyncSender implements Sender {
   private final String url;
   private final JsonSerializer jsonSerializer;
   private final String accessToken;
+  private final boolean compressPayload;
 
   AsyncSender(Builder builder) {
     this.httpClient = builder.httpClient;
     this.url = builder.url.toExternalForm();
     this.jsonSerializer = builder.jsonSerializer;
     this.accessToken = builder.accessToken;
+    this.compressPayload = builder.compressPayload;
   }
 
   /**
@@ -49,10 +54,15 @@ public class AsyncSender implements Sender {
     headers.put("Content-Type", "application/json; charset=" + SyncSender.UTF_8);
     headers.put("Accept", "application/json");
 
-    String reqBody = jsonSerializer.toJson(payload);
+    String json = jsonSerializer.toJson(payload);
 
-    AsyncHttpRequest request =
-        AsyncHttpRequest.Builder.build(this.url, headers.entrySet(), reqBody);
+    AsyncHttpRequest request;
+    if (compressPayload) {
+      headers.put("Content-Encoding", "gzip");
+      request = AsyncHttpRequest.Builder.build(this.url, headers.entrySet(), compress(json));
+    } else {
+      request = AsyncHttpRequest.Builder.build(this.url, headers.entrySet(), json);
+    }
 
     return Utils.map(httpClient.send(request),
         new Utils.Converter<AsyncHttpResponse, Response>() {
@@ -62,6 +72,18 @@ public class AsyncSender implements Sender {
             return new Response.Builder().result(result).status(from.getStatusCode()).build();
           }
         });
+  }
+
+  private static byte[] compress(String json) {
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      GZIPOutputStream gzip = new GZIPOutputStream(baos);
+      gzip.write(json.getBytes(SyncSender.UTF_8));
+      gzip.close();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to gzip-compress payload", e);
+    }
   }
 
   @Override
@@ -82,6 +104,7 @@ public class AsyncSender implements Sender {
     private URL url;
     private JsonSerializer jsonSerializer;
     private String accessToken;
+    private boolean compressPayload = true;
 
     /**
      * Constructor.
@@ -145,6 +168,17 @@ public class AsyncSender implements Sender {
      */
     public Builder accessToken(String accessToken) {
       this.accessToken = accessToken;
+      return this;
+    }
+
+    /**
+     * Whether to gzip-compress payloads before sending. Default: true.
+     *
+     * @param compress true to enable compression.
+     * @return the builder instance.
+     */
+    public Builder compressPayload(boolean compress) {
+      this.compressPayload = compress;
       return this;
     }
 

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/AsyncSender.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/AsyncSender.java
@@ -10,12 +10,9 @@ import com.rollbar.reactivestreams.Utils;
 import com.rollbar.reactivestreams.notifier.sender.http.AsyncHttpClient;
 import com.rollbar.reactivestreams.notifier.sender.http.AsyncHttpRequest;
 import com.rollbar.reactivestreams.notifier.sender.http.AsyncHttpResponse;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedHashMap;
-import java.util.zip.GZIPOutputStream;
 import org.reactivestreams.Publisher;
 
 /**
@@ -56,13 +53,8 @@ public class AsyncSender implements Sender {
 
     String json = jsonSerializer.toJson(payload);
 
-    AsyncHttpRequest request;
-    if (compressPayload) {
-      headers.put("Content-Encoding", "gzip");
-      request = AsyncHttpRequest.Builder.build(this.url, headers.entrySet(), compress(json));
-    } else {
-      request = AsyncHttpRequest.Builder.build(this.url, headers.entrySet(), json);
-    }
+    AsyncHttpRequest request =
+        AsyncHttpRequest.Builder.build(this.url, headers.entrySet(), json, compressPayload);
 
     return Utils.map(httpClient.send(request),
         new Utils.Converter<AsyncHttpResponse, Response>() {
@@ -72,18 +64,6 @@ public class AsyncSender implements Sender {
             return new Response.Builder().result(result).status(from.getStatusCode()).build();
           }
         });
-  }
-
-  private static byte[] compress(String json) {
-    try {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      GZIPOutputStream gzip = new GZIPOutputStream(baos);
-      gzip.write(json.getBytes(SyncSender.UTF_8));
-      gzip.close();
-      return baos.toByteArray();
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to gzip-compress payload", e);
-    }
   }
 
   @Override

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheRequestPublisher.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheRequestPublisher.java
@@ -102,7 +102,11 @@ class ApacheRequestPublisher implements Publisher<SimpleHttpResponse> {
         req.setHeader(header.getKey(), header.getValue());
       }
 
-      req.setBody(request.getBody(), ContentType.APPLICATION_JSON);
+      if (request.getBodyBytes() != null) {
+        req.setBody(request.getBodyBytes(), ContentType.APPLICATION_JSON);
+      } else {
+        req.setBody(request.getBody(), ContentType.APPLICATION_JSON);
+      }
 
       return SimpleRequestProducer.create(req);
     }

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheRequestPublisher.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheRequestPublisher.java
@@ -1,10 +1,14 @@
 package com.rollbar.reactivestreams.notifier.sender.http;
 
+import com.rollbar.notifier.sender.SyncSender;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPOutputStream;
 import org.apache.hc.client5.http.async.HttpAsyncClient;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
@@ -102,8 +106,9 @@ class ApacheRequestPublisher implements Publisher<SimpleHttpResponse> {
         req.setHeader(header.getKey(), header.getValue());
       }
 
-      if (request.getBodyBytes() != null) {
-        req.setBody(request.getBodyBytes(), ContentType.APPLICATION_JSON);
+      if (request.isCompressionRequested()) {
+        req.addHeader("Content-Encoding", "gzip");
+        req.setBody(compress(request.getBody()), ContentType.APPLICATION_JSON);
       } else {
         req.setBody(request.getBody(), ContentType.APPLICATION_JSON);
       }
@@ -118,6 +123,18 @@ class ApacheRequestPublisher implements Publisher<SimpleHttpResponse> {
       if (request != null) {
         request.cancel(false);
       }
+    }
+  }
+
+  private static byte[] compress(String json) {
+    try {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      GZIPOutputStream gzip = new GZIPOutputStream(baos);
+      gzip.write(json.getBytes(SyncSender.UTF_8));
+      gzip.close();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to gzip-compress payload", e);
     }
   }
 }

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheRequestPublisher.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheRequestPublisher.java
@@ -129,9 +129,9 @@ class ApacheRequestPublisher implements Publisher<SimpleHttpResponse> {
   private static byte[] compress(String json) {
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      GZIPOutputStream gzip = new GZIPOutputStream(baos);
-      gzip.write(json.getBytes(SyncSender.UTF_8));
-      gzip.close();
+      try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+        gzip.write(json.getBytes(SyncSender.UTF_8));
+      }
       return baos.toByteArray();
     } catch (IOException e) {
       throw new RuntimeException("Failed to gzip-compress payload", e);

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequest.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequest.java
@@ -13,10 +13,19 @@ public interface AsyncHttpRequest {
 
   String getBody();
 
+  default byte[] getBodyBytes() {
+    return null;
+  }
+
   class Builder {
     public static AsyncHttpRequest build(String url, Set<Map.Entry<String, String>> headers,
                                          String reqBody) {
       return new AsyncHttpRequestImpl(url, headers, reqBody);
+    }
+
+    public static AsyncHttpRequest build(String url, Set<Map.Entry<String, String>> headers,
+                                         byte[] body) {
+      return new AsyncHttpRequestImpl(url, headers, body);
     }
   }
 }

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequest.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequest.java
@@ -13,19 +13,19 @@ public interface AsyncHttpRequest {
 
   String getBody();
 
-  default byte[] getBodyBytes() {
-    return null;
+  default boolean isCompressionRequested() {
+    return false;
   }
 
   class Builder {
     public static AsyncHttpRequest build(String url, Set<Map.Entry<String, String>> headers,
                                          String reqBody) {
-      return new AsyncHttpRequestImpl(url, headers, reqBody);
+      return new AsyncHttpRequestImpl(url, headers, reqBody, false);
     }
 
     public static AsyncHttpRequest build(String url, Set<Map.Entry<String, String>> headers,
-                                         byte[] body) {
-      return new AsyncHttpRequestImpl(url, headers, body);
+                                         String reqBody, boolean compressionRequested) {
+      return new AsyncHttpRequestImpl(url, headers, reqBody, compressionRequested);
     }
   }
 }

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequestImpl.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequestImpl.java
@@ -9,19 +9,22 @@ class AsyncHttpRequestImpl implements AsyncHttpRequest {
   private final String url;
   private final Iterable<Map.Entry<String, String>> headers;
   private final String body;
+  private final byte[] bodyBytes;
 
-  /**
-   * Constructor.
-   *
-   * @param url The URL to connect to.
-   * @param headers Request headers.
-   * @param body Request body.
-   */
   public AsyncHttpRequestImpl(String url, Iterable<Map.Entry<String, String>> headers,
                               String body) {
     this.url = url;
     this.headers = headers;
     this.body = body;
+    this.bodyBytes = null;
+  }
+
+  public AsyncHttpRequestImpl(String url, Iterable<Map.Entry<String, String>> headers,
+                              byte[] bodyBytes) {
+    this.url = url;
+    this.headers = headers;
+    this.body = null;
+    this.bodyBytes = bodyBytes;
   }
 
   @Override
@@ -37,5 +40,10 @@ class AsyncHttpRequestImpl implements AsyncHttpRequest {
   @Override
   public String getBody() {
     return body;
+  }
+
+  @Override
+  public byte[] getBodyBytes() {
+    return bodyBytes;
   }
 }

--- a/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequestImpl.java
+++ b/rollbar-reactive-streams/src/main/java/com/rollbar/reactivestreams/notifier/sender/http/AsyncHttpRequestImpl.java
@@ -9,22 +9,14 @@ class AsyncHttpRequestImpl implements AsyncHttpRequest {
   private final String url;
   private final Iterable<Map.Entry<String, String>> headers;
   private final String body;
-  private final byte[] bodyBytes;
+  private final boolean compressionRequested;
 
   public AsyncHttpRequestImpl(String url, Iterable<Map.Entry<String, String>> headers,
-                              String body) {
+                              String body, boolean compressionRequested) {
     this.url = url;
     this.headers = headers;
     this.body = body;
-    this.bodyBytes = null;
-  }
-
-  public AsyncHttpRequestImpl(String url, Iterable<Map.Entry<String, String>> headers,
-                              byte[] bodyBytes) {
-    this.url = url;
-    this.headers = headers;
-    this.body = null;
-    this.bodyBytes = bodyBytes;
+    this.compressionRequested = compressionRequested;
   }
 
   @Override
@@ -43,7 +35,7 @@ class AsyncHttpRequestImpl implements AsyncHttpRequest {
   }
 
   @Override
-  public byte[] getBodyBytes() {
-    return bodyBytes;
+  public boolean isCompressionRequested() {
+    return compressionRequested;
   }
 }

--- a/rollbar-reactive-streams/src/test/java/com/rollbar/reactivestreams/notifier/sender/AsyncSenderTest.java
+++ b/rollbar-reactive-streams/src/test/java/com/rollbar/reactivestreams/notifier/sender/AsyncSenderTest.java
@@ -52,6 +52,7 @@ public class AsyncSenderTest {
 
     sender = new AsyncSender.Builder(httpClient)
             .accessToken(ACCESS_TOKEN)
+            .compressPayload(false)
             .build();
   }
   

--- a/rollbar-reactive-streams/src/test/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheAsyncHttpTckTest.java
+++ b/rollbar-reactive-streams/src/test/java/com/rollbar/reactivestreams/notifier/sender/http/ApacheAsyncHttpTckTest.java
@@ -74,7 +74,7 @@ public class ApacheAsyncHttpTckTest extends PublisherVerification<SimpleHttpResp
     });
 
     return new ApacheRequestPublisher(client, new AsyncHttpRequestImpl(url,
-        new LinkedHashMap<String, String>().entrySet(), ""));
+        new LinkedHashMap<String, String>().entrySet(), "", false));
   }
 
   @Override
@@ -85,7 +85,7 @@ public class ApacheAsyncHttpTckTest extends PublisherVerification<SimpleHttpResp
     });
 
     return new ApacheRequestPublisher(client, new AsyncHttpRequestImpl(url,
-        new LinkedHashMap<String, String>().entrySet(), ""));
+        new LinkedHashMap<String, String>().entrySet(), "", false));
   }
 
   @Override


### PR DESCRIPTION
## Description of the change

  ### Larger payload limit                                                                                                                                                                                                               
  The maximum payload size has been raised from 512 KB to **1 MB**. 
                                                                                                                                                                                                                                         
  ### Gzip compression                                                                                                                                                                                                                   
  Payloads are now **gzip-compressed by default** before being sent to Rollbar. This significantly reduces bandwidth — in practice around 10× on typical JSON error payloads.                                                            
                                                                                                                                                                                                                                         
  Compression can be turned off if needed:                                                                                                                                                                                               
                                                                                                                                                                                                                                         
  **rollbar-java / rollbar-android**                                                                                                                                                                                                     
  ```java
  Rollbar.init(context, "ACCESS_TOKEN", "production",
      config -> config.compressPayload(false));
  ```
  rollbar-reactive-streams
  ```java
  ConfigBuilder.withAccessToken("ACCESS_TOKEN")
      .compressPayload(false)
      .build();
  ```               
  ▎ Note for custom AsyncHttpClient implementations: if you have plugged in your own AsyncHttpClient via ConfigBuilder.httpClient(...), compression is signalled via request.isCompressionRequested(). Your client will still receive the
  ▎  full JSON body via request.getBody() — it will just be sent uncompressed unless you handle the flag yourself.


### 1 - Big uncompressed example payload (841kb)
<img width="1899" height="816" alt="Captura de pantalla 2026-05-03 a la(s) 3 36 27 p  m" src="https://github.com/user-attachments/assets/482967f1-1f51-43ab-b9aa-4bf795c4b17a" />

### 2 - Big uncompressed example payload exceeding limit (1.27mb)
<img width="1897" height="827" alt="Captura de pantalla 2026-05-03 a la(s) 3 36 32 p  m" src="https://github.com/user-attachments/assets/65f5e840-3473-4c16-86f8-725dedb3ae57" />

### 3- Same payload as 2, but compressed (10kb)
<img width="1899" height="836" alt="Captura de pantalla 2026-05-03 a la(s) 3 36 38 p  m" src="https://github.com/user-attachments/assets/4a423c73-25b0-44a8-adef-6a0423b6234a" />


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
